### PR TITLE
Calculate lower bounds inside range + adaptive update

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/config/context/SchedulersConfig.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/config/context/SchedulersConfig.kt
@@ -15,17 +15,17 @@ import java.util.concurrent.Executors
 
 @Configuration
 open class SchedulersConfig {
-    private val log = LoggerFactory.getLogger(SchedulersConfig::class.java)
-    private val threadsMultiplier: Int
 
-    init {
-        val cores = Runtime.getRuntime().availableProcessors()
-        threadsMultiplier = if (cores < 3) {
-            1
-        } else {
-            cores / 2
-        }
-        log.info("Creating schedulers with multiplier: {}...", threadsMultiplier)
+    companion object {
+        private val log = LoggerFactory.getLogger(SchedulersConfig::class.java)
+        val threadsMultiplier = run {
+            val cores = Runtime.getRuntime().availableProcessors()
+            if (cores < 3) {
+                1
+            } else {
+                cores / 2
+            }
+        }.also { log.info("Creating schedulers with multiplier: {}...", it) }
     }
 
     @Bean

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/DefaultUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/DefaultUpstream.kt
@@ -23,6 +23,7 @@ import io.emeraldpay.dshackle.foundation.ChainOptions
 import io.emeraldpay.dshackle.startup.QuorumForLabels
 import io.emeraldpay.dshackle.startup.UpstreamChangeEvent
 import io.emeraldpay.dshackle.upstream.calls.CallMethods
+import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Sinks
@@ -152,6 +153,10 @@ abstract class DefaultUpstream(
 
     override fun getId(): String {
         return id
+    }
+
+    override fun updateLowerBound(lowerBound: Long, type: LowerBoundType) {
+        // NOOP
     }
 
     data class Status(val lag: Long?, val avail: UpstreamAvailability, val status: UpstreamAvailability)

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
@@ -420,6 +420,10 @@ abstract class Multistream(
 
     override fun nodeId(): Byte = 0
 
+    override fun updateLowerBound(lowerBound: Long, type: LowerBoundType) {
+        // NOOP
+    }
+
     fun printStatus() {
         var height: Long? = null
         try {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Upstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Upstream.kt
@@ -22,6 +22,7 @@ import io.emeraldpay.dshackle.reader.ChainReader
 import io.emeraldpay.dshackle.startup.UpstreamChangeEvent
 import io.emeraldpay.dshackle.upstream.calls.CallMethods
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundData
+import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
 import reactor.core.publisher.Flux
 
 interface Upstream : Lifecycle {
@@ -47,6 +48,7 @@ interface Upstream : Lifecycle {
     fun isGrpc(): Boolean
     fun getLowerBounds(): Collection<LowerBoundData>
     fun getUpstreamSettingsData(): UpstreamSettingsData?
+    fun updateLowerBound(lowerBound: Long, type: LowerBoundType)
 
     fun <T : Upstream> cast(selfType: Class<T>): T
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/beaconchain/BeaconChainLowerBoundStateDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/beaconchain/BeaconChainLowerBoundStateDetector.kt
@@ -14,4 +14,8 @@ class BeaconChainLowerBoundStateDetector : LowerBoundDetector() {
     override fun internalDetectLowerBound(): Flux<LowerBoundData> {
         return Flux.just(LowerBoundData(1, LowerBoundType.STATE))
     }
+
+    override fun types(): Set<LowerBoundType> {
+        return setOf(LowerBoundType.STATE)
+    }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/error/EthereumStateLowerBoundErrorHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/error/EthereumStateLowerBoundErrorHandler.kt
@@ -1,0 +1,66 @@
+package io.emeraldpay.dshackle.upstream.error
+
+import io.emeraldpay.dshackle.upstream.ChainRequest
+import io.emeraldpay.dshackle.upstream.Upstream
+import io.emeraldpay.dshackle.upstream.ethereum.EthereumLowerBoundStateDetector.Companion.stateErrors
+import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
+import io.emeraldpay.dshackle.upstream.rpcclient.ListParams
+import org.slf4j.LoggerFactory
+
+object EthereumStateLowerBoundErrorHandler : ErrorHandler {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    private val firstTagIndexMethods = setOf(
+        "eth_call",
+        "debug_traceCall",
+        "eth_getBalance",
+        "eth_estimateGas",
+        "eth_getCode",
+        "eth_getTransactionCount",
+    )
+    private val secondTagIndexMethods = setOf(
+        "eth_getProof",
+        "eth_getStorageAt",
+    )
+
+    private val applicableMethods = firstTagIndexMethods + secondTagIndexMethods
+
+    override fun handle(upstream: Upstream, request: ChainRequest, errorMessage: String?) {
+        try {
+            if (canHandle(request, errorMessage)) {
+                parseTagParam(request, tagIndex(request.method))?.let {
+                    upstream.updateLowerBound(it, LowerBoundType.STATE)
+                }
+            }
+        } catch (e: RuntimeException) {
+            log.warn("Couldn't update the {} lower bound of {}, reason - {}", LowerBoundType.STATE, upstream.getId(), e.message)
+        }
+    }
+
+    override fun canHandle(request: ChainRequest, errorMessage: String?): Boolean {
+        return stateErrors.any { errorMessage?.contains(it) ?: false } && applicableMethods.contains(request.method)
+    }
+
+    private fun parseTagParam(request: ChainRequest, tagIndex: Int): Long? {
+        if (tagIndex != -1 && request.params is ListParams) {
+            val params = request.params.list
+            if (params.size >= tagIndex) {
+                val tag = params[tagIndex]
+                if (tag is String && tag.startsWith("0x")) {
+                    return tag.substring(2).toLong(16)
+                }
+            }
+        }
+        return null
+    }
+
+    private fun tagIndex(method: String): Int {
+        return if (firstTagIndexMethods.contains(method)) {
+            1
+        } else if (secondTagIndexMethods.contains(method)) {
+            2
+        } else {
+            -1
+        }
+    }
+}

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/error/UpstreamErrorHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/error/UpstreamErrorHandler.kt
@@ -1,0 +1,25 @@
+package io.emeraldpay.dshackle.upstream.error
+
+import io.emeraldpay.dshackle.upstream.ChainRequest
+import io.emeraldpay.dshackle.upstream.Upstream
+import java.util.concurrent.CompletableFuture
+
+interface ErrorHandler {
+    fun handle(upstream: Upstream, request: ChainRequest, errorMessage: String?)
+
+    fun canHandle(request: ChainRequest, errorMessage: String?): Boolean
+}
+
+object UpstreamErrorHandler {
+    private val errorHandlers = listOf(
+        EthereumStateLowerBoundErrorHandler,
+    )
+
+    fun handle(upstream: Upstream, request: ChainRequest, errorMessage: String?) {
+        CompletableFuture.runAsync {
+            errorHandlers
+                .filter { it.canHandle(request, errorMessage) }
+                .forEach { it.handle(upstream, request, errorMessage) }
+        }
+    }
+}

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/error/UpstreamErrorHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/error/UpstreamErrorHandler.kt
@@ -1,8 +1,11 @@
 package io.emeraldpay.dshackle.upstream.error
 
+import io.emeraldpay.dshackle.config.context.SchedulersConfig
 import io.emeraldpay.dshackle.upstream.ChainRequest
 import io.emeraldpay.dshackle.upstream.Upstream
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
 
 interface ErrorHandler {
     fun handle(upstream: Upstream, request: ChainRequest, errorMessage: String?)
@@ -14,12 +17,19 @@ object UpstreamErrorHandler {
     private val errorHandlers = listOf(
         EthereumStateLowerBoundErrorHandler,
     )
+    private val errorHandlerExecutor = Executors.newFixedThreadPool(
+        2 * SchedulersConfig.threadsMultiplier,
+        CustomizableThreadFactory("error-handler-"),
+    )
 
     fun handle(upstream: Upstream, request: ChainRequest, errorMessage: String?) {
-        CompletableFuture.runAsync {
-            errorHandlers
-                .filter { it.canHandle(request, errorMessage) }
-                .forEach { it.handle(upstream, request, errorMessage) }
-        }
+        CompletableFuture.runAsync(
+            {
+                errorHandlers
+                    .filter { it.canHandle(request, errorMessage) }
+                    .forEach { it.handle(upstream, request, errorMessage) }
+            },
+            errorHandlerExecutor,
+        )
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLowerBoundBlockDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLowerBoundBlockDetector.kt
@@ -15,7 +15,7 @@ import reactor.core.publisher.Mono
 class EthereumLowerBoundBlockDetector(
     private val upstream: Upstream,
 ) : LowerBoundDetector() {
-    private val recursiveLowerBound = RecursiveLowerBound(upstream, LowerBoundType.BLOCK, setOf("No block data"))
+    private val recursiveLowerBound = RecursiveLowerBound(upstream, LowerBoundType.BLOCK, setOf("No block data"), lowerBounds)
 
     override fun period(): Long {
         return 3
@@ -40,5 +40,9 @@ class EthereumLowerBoundBlockDetector(
                     }
             }
         }
+    }
+
+    override fun types(): Set<LowerBoundType> {
+        return setOf(LowerBoundType.BLOCK)
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLowerBoundStateDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLowerBoundStateDetector.kt
@@ -15,10 +15,10 @@ import reactor.core.publisher.Mono
 class EthereumLowerBoundStateDetector(
     private val upstream: Upstream,
 ) : LowerBoundDetector() {
-    private val recursiveLowerBound = RecursiveLowerBound(upstream, LowerBoundType.STATE, nonRetryableErrors)
+    private val recursiveLowerBound = RecursiveLowerBound(upstream, LowerBoundType.STATE, stateErrors, lowerBounds)
 
     companion object {
-        private val nonRetryableErrors = setOf(
+        val stateErrors = setOf(
             "No state available for block", // nethermind
             "missing trie node", // geth
             "header not found", // optimism, bsc, avalanche
@@ -61,5 +61,9 @@ class EthereumLowerBoundStateDetector(
                 )
             }
         }
+    }
+
+    override fun types(): Set<LowerBoundType> {
+        return setOf(LowerBoundType.STATE)
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/GenericUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/GenericUpstream.kt
@@ -25,6 +25,7 @@ import io.emeraldpay.dshackle.upstream.generic.connectors.ConnectorFactory
 import io.emeraldpay.dshackle.upstream.generic.connectors.GenericConnector
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundData
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundServiceBuilder
+import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
 import org.springframework.context.Lifecycle
 import reactor.core.Disposable
 import reactor.core.publisher.Flux
@@ -244,6 +245,10 @@ open class GenericUpstream(
     }
 
     override fun isRunning() = connector.isRunning() || started.get()
+
+    override fun updateLowerBound(lowerBound: Long, type: LowerBoundType) {
+        lowerBoundService.updateLowerBound(lowerBound, type)
+    }
 
     fun isValid(): Boolean = isUpstreamValid.get()
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/lowerbound/LowerBoundDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/lowerbound/LowerBoundDetector.kt
@@ -3,6 +3,7 @@ package io.emeraldpay.dshackle.upstream.lowerbound
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.core.publisher.Sinks
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
@@ -12,23 +13,27 @@ fun Long.toHex() = "0x${this.toString(16)}"
 abstract class LowerBoundDetector {
     protected val log = LoggerFactory.getLogger(this::class.java)
 
-    private val lowerBounds = ConcurrentHashMap<LowerBoundType, LowerBoundData>()
+    protected val lowerBounds = ConcurrentHashMap<LowerBoundType, LowerBoundData>()
+    private val lowerBoundSink = Sinks.many().multicast().directBestEffort<LowerBoundData>()
 
     fun detectLowerBound(): Flux<LowerBoundData> {
         val notProcessing = AtomicBoolean(true)
 
-        return Flux.interval(
-            Duration.ofSeconds(15),
-            Duration.ofMinutes(period()),
+        return Flux.merge(
+            lowerBoundSink.asFlux(),
+            Flux.interval(
+                Duration.ofSeconds(15),
+                Duration.ofMinutes(period()),
+            )
+                .filter { notProcessing.get() }
+                .flatMap {
+                    notProcessing.set(false)
+                    internalDetectLowerBound()
+                        .onErrorResume { Mono.just(LowerBoundData.default()) }
+                        .switchIfEmpty(Flux.just(LowerBoundData.default()))
+                        .doFinally { notProcessing.set(true) }
+                },
         )
-            .filter { notProcessing.get() }
-            .flatMap {
-                notProcessing.set(false)
-                internalDetectLowerBound()
-                    .onErrorResume { Mono.just(LowerBoundData.default()) }
-                    .switchIfEmpty(Flux.just(LowerBoundData.default()))
-                    .doFinally { notProcessing.set(true) }
-            }
             .filter {
                 it.lowerBound >= (lowerBounds[it.type]?.lowerBound ?: 0)
             }
@@ -42,4 +47,10 @@ abstract class LowerBoundDetector {
     protected abstract fun period(): Long
 
     protected abstract fun internalDetectLowerBound(): Flux<LowerBoundData>
+
+    abstract fun types(): Set<LowerBoundType>
+
+    fun updateLowerBound(lowerBound: Long, type: LowerBoundType) {
+        lowerBoundSink.emitNext(LowerBoundData(lowerBound, type)) { _, res -> res == Sinks.EmitResult.FAIL_NON_SERIALIZED }
+    }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/lowerbound/detector/RecursiveLowerBound.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/lowerbound/detector/RecursiveLowerBound.kt
@@ -16,6 +16,7 @@ class RecursiveLowerBound(
     private val upstream: Upstream,
     private val type: LowerBoundType,
     private val nonRetryableErrors: Set<String>,
+    private val lowerBounds: Map<LowerBoundType, LowerBoundData>,
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -25,8 +26,11 @@ class RecursiveLowerBound(
                 val currentHeight = it.getCurrentHeight()
                 if (currentHeight == null) {
                     Mono.empty()
-                } else {
+                } else if (!lowerBounds.contains(type)) {
                     Mono.just(LowerBoundBinarySearch(0, currentHeight))
+                } else {
+                    // next calculations will be carried out only within the last range
+                    Mono.just(LowerBoundBinarySearch(lowerBounds[type]!!.lowerBound, currentHeight))
                 }
             }
             .expand { data ->

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/near/NearLowerBoundStateDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/near/NearLowerBoundStateDetector.kt
@@ -24,4 +24,8 @@ class NearLowerBoundStateDetector(
             LowerBoundData(resp.syncInfo.earliestHeight, LowerBoundType.STATE)
         }.toFlux()
     }
+
+    override fun types(): Set<LowerBoundType> {
+        return setOf(LowerBoundType.STATE)
+    }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/polkadot/PolkadotLowerBoundStateDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/polkadot/PolkadotLowerBoundStateDetector.kt
@@ -14,7 +14,7 @@ import reactor.core.publisher.Flux
 class PolkadotLowerBoundStateDetector(
     private val upstream: Upstream,
 ) : LowerBoundDetector() {
-    private val recursiveLowerBound = RecursiveLowerBound(upstream, LowerBoundType.STATE, nonRetryableErrors)
+    private val recursiveLowerBound = RecursiveLowerBound(upstream, LowerBoundType.STATE, nonRetryableErrors, lowerBounds)
 
     companion object {
         private val nonRetryableErrors = setOf(
@@ -47,5 +47,9 @@ class PolkadotLowerBoundStateDetector(
                     )
                 }
         }
+    }
+
+    override fun types(): Set<LowerBoundType> {
+        return setOf(LowerBoundType.STATE)
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/solana/SolanaLowerBoundSlotDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/solana/SolanaLowerBoundSlotDetector.kt
@@ -76,4 +76,8 @@ class SolanaLowerBoundSlotDetector(
                     },
             )
     }
+
+    override fun types(): Set<LowerBoundType> {
+        return setOf(LowerBoundType.SLOT, LowerBoundType.STATE)
+    }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/starknet/StarknetLowerBoundStateDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/starknet/StarknetLowerBoundStateDetector.kt
@@ -14,4 +14,8 @@ class StarknetLowerBoundStateDetector : LowerBoundDetector() {
     override fun internalDetectLowerBound(): Flux<LowerBoundData> {
         return Flux.just(LowerBoundData(1, LowerBoundType.STATE))
     }
+
+    override fun types(): Set<LowerBoundType> {
+        return setOf(LowerBoundType.STATE)
+    }
 }

--- a/src/test/kotlin/io/emeraldpay/dshackle/upstream/error/EthereumStateLowerBoundErrorHandlerTest.kt
+++ b/src/test/kotlin/io/emeraldpay/dshackle/upstream/error/EthereumStateLowerBoundErrorHandlerTest.kt
@@ -1,0 +1,73 @@
+package io.emeraldpay.dshackle.upstream.error
+
+import io.emeraldpay.dshackle.upstream.ChainRequest
+import io.emeraldpay.dshackle.upstream.Upstream
+import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
+import io.emeraldpay.dshackle.upstream.rpcclient.ListParams
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.of
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.Mockito.anyLong
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class EthereumStateLowerBoundErrorHandlerTest {
+
+    @ParameterizedTest
+    @MethodSource("requests")
+    fun `update lower bound`(request: ChainRequest) {
+        val upstream = mock<Upstream>()
+        val handler = EthereumStateLowerBoundErrorHandler
+
+        handler.handle(upstream, request, "missing trie node d5648cc9aef48154159d53800f2f")
+
+        verify(upstream).updateLowerBound(213229736, LowerBoundType.STATE)
+    }
+
+    @Test
+    fun `no update lower bound if error is not about state`() {
+        val upstream = mock<Upstream>()
+        val request = ChainRequest(
+            "eth_getTransactionCount",
+            ListParams("0x343", "0xCB5A0A8"),
+        )
+        val handler = EthereumStateLowerBoundErrorHandler
+
+        handler.handle(upstream, request, "strange error")
+
+        verify(upstream, never()).updateLowerBound(anyLong(), any())
+    }
+
+    @Test
+    fun `no update lower bound if there is a non-state method`() {
+        val upstream = mock<Upstream>()
+        val request = ChainRequest(
+            "eth_getBlockByNumber",
+            ListParams("0xCB5A0A8", true),
+        )
+        val handler = EthereumStateLowerBoundErrorHandler
+
+        handler.handle(upstream, request, "missing trie node d5648cc9aef48154159d53800f2f")
+
+        verify(upstream, never()).updateLowerBound(anyLong(), any())
+    }
+
+    companion object {
+        @JvmStatic
+        fun requests(): List<Arguments> =
+            listOf(
+                of(ChainRequest("eth_getTransactionCount", ListParams("0x343", "0xCB5A0A8"))),
+                of(ChainRequest("eth_getCode", ListParams("0x343", "0xCB5A0A8"))),
+                of(ChainRequest("eth_estimateGas", ListParams("0x343", "0xCB5A0A8"))),
+                of(ChainRequest("eth_getBalance", ListParams("0x343", "0xCB5A0A8"))),
+                of(ChainRequest("debug_traceCall", ListParams("0x343", "0xCB5A0A8"))),
+                of(ChainRequest("eth_call", ListParams("0x343", "0xCB5A0A8"))),
+                of(ChainRequest("eth_getProof", ListParams("0x343", "test", "0xCB5A0A8"))),
+                of(ChainRequest("eth_getStorageAt", ListParams("0x343", "test", "0xCB5A0A8"))),
+            )
+    }
+}

--- a/src/test/kotlin/io/emeraldpay/dshackle/upstream/error/UpstreamErrorHandlerTest.kt
+++ b/src/test/kotlin/io/emeraldpay/dshackle/upstream/error/UpstreamErrorHandlerTest.kt
@@ -18,6 +18,8 @@ class UpstreamErrorHandlerTest {
 
         handler.handle(upstream, request, "missing trie node d5648cc9aef48154159d53800f2f")
 
+        Thread.sleep(100)
+
         verify(upstream).updateLowerBound(213229736, LowerBoundType.STATE)
     }
 }

--- a/src/test/kotlin/io/emeraldpay/dshackle/upstream/error/UpstreamErrorHandlerTest.kt
+++ b/src/test/kotlin/io/emeraldpay/dshackle/upstream/error/UpstreamErrorHandlerTest.kt
@@ -1,0 +1,23 @@
+package io.emeraldpay.dshackle.upstream.error
+
+import io.emeraldpay.dshackle.upstream.ChainRequest
+import io.emeraldpay.dshackle.upstream.Upstream
+import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
+import io.emeraldpay.dshackle.upstream.rpcclient.ListParams
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
+
+class UpstreamErrorHandlerTest {
+
+    @Test
+    fun `use lower bound error handler`() {
+        val upstream = mock<Upstream>()
+        val request = ChainRequest("eth_getCode", ListParams("0x343", "0xCB5A0A8"))
+        val handler = UpstreamErrorHandler
+
+        handler.handle(upstream, request, "missing trie node d5648cc9aef48154159d53800f2f")
+
+        verify(upstream).updateLowerBound(213229736, LowerBoundType.STATE)
+    }
+}


### PR DESCRIPTION
We must calculate the next lower bound only inside the range `lowerBound-head`. Also we have to track errors from nodes and update lower bounds if we face with some error types.