### PR TITLE
Track upstream finalization data

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/rpc/NativeCall.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/rpc/NativeCall.kt
@@ -720,7 +720,7 @@ open class NativeCall(
         val upstreamSettingsData: Upstream.UpstreamSettingsData?,
         val ctx: ValidCallContext<ParsedCallDetails>?,
         val stream: Flux<Chunk>? = null,
-        val finalization: FinalizationData? = null
+        val finalization: FinalizationData? = null,
     ) {
 
         constructor(

--- a/src/main/kotlin/io/emeraldpay/dshackle/rpc/NativeCall.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/rpc/NativeCall.kt
@@ -19,6 +19,7 @@ package io.emeraldpay.dshackle.rpc
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.protobuf.ByteString
 import io.emeraldpay.api.proto.BlockchainOuterClass
+import io.emeraldpay.api.proto.Common
 import io.emeraldpay.dshackle.Chain
 import io.emeraldpay.dshackle.Global
 import io.emeraldpay.dshackle.Global.Companion.nullValue
@@ -245,7 +246,7 @@ open class NativeCall(
             result.upstreamNodeVersion = it.nodeVersion
         }
         it.finalization?.let {
-            result.finalization = BlockchainOuterClass.FinalizationData.newBuilder()
+            result.finalization = Common.FinalizationData.newBuilder()
                 .setHeight(it.height)
                 .setType(it.type.toProtoFinalizationType())
                 .build()

--- a/src/main/kotlin/io/emeraldpay/dshackle/rpc/NativeCall.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/rpc/NativeCall.kt
@@ -47,6 +47,7 @@ import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.calls.DefaultEthereumMethods
 import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcException
 import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcResponseError
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
 import io.emeraldpay.dshackle.upstream.rpcclient.CallParams
 import io.emeraldpay.dshackle.upstream.rpcclient.ListParams
 import io.emeraldpay.dshackle.upstream.rpcclient.ObjectParams
@@ -243,6 +244,12 @@ open class NativeCall(
             result.upstreamId = it.id
             result.upstreamNodeVersion = it.nodeVersion
         }
+        it.finalization?.let {
+            result.finalization = BlockchainOuterClass.FinalizationData.newBuilder()
+                .setHeight(it.height)
+                .setType(it.type.toProtoFinalizationType())
+                .build()
+        }
         return result.build()
     }
 
@@ -426,9 +433,9 @@ open class NativeCall(
                         val resolvedUpstreamData = it.resolvedUpstreamData ?: ctx.upstream.getUpstreamSettingsData()
                         validateResult(result, "local", ctx)
                         if (ctx.nonce != null) {
-                            CallResult.ok(ctx.id, ctx.nonce, result, signer.sign(ctx.nonce, result, resolvedUpstreamData?.id ?: ctx.upstream.getId()), resolvedUpstreamData, ctx)
+                            CallResult.ok(ctx.id, ctx.nonce, result, signer.sign(ctx.nonce, result, resolvedUpstreamData?.id ?: ctx.upstream.getId()), resolvedUpstreamData, ctx, it.finalization)
                         } else {
-                            CallResult.ok(ctx.id, null, result, null, resolvedUpstreamData, ctx)
+                            CallResult.ok(ctx.id, null, result, null, resolvedUpstreamData, ctx, it.finalization)
                         }
                     }
             }.switchIfEmpty(
@@ -436,6 +443,10 @@ open class NativeCall(
             )
             .onErrorResume {
                 Mono.just(CallResult.fail(ctx.id, ctx.nonce, it, ctx))
+            }.doOnNext {
+                if (it.finalization != null && it.upstreamSettingsData != null) {
+                    ctx.upstream.addFinalization(it.finalization, it.upstreamSettingsData.id)
+                }
             }
     }
 
@@ -700,7 +711,7 @@ open class NativeCall(
         }
     }
 
-    open class CallResult(
+    open class CallResult @JvmOverloads constructor(
         val id: Int,
         val nonce: Long?,
         val result: ByteArray?,
@@ -709,6 +720,7 @@ open class NativeCall(
         val upstreamSettingsData: Upstream.UpstreamSettingsData?,
         val ctx: ValidCallContext<ParsedCallDetails>?,
         val stream: Flux<Chunk>? = null,
+        val finalization: FinalizationData? = null
     ) {
 
         constructor(
@@ -723,6 +735,10 @@ open class NativeCall(
         companion object {
             fun ok(id: Int, nonce: Long?, result: ByteArray, signature: ResponseSigner.Signature?, upstreamSettingsData: Upstream.UpstreamSettingsData?, ctx: ValidCallContext<ParsedCallDetails>?): CallResult {
                 return CallResult(id, nonce, result, null, signature, upstreamSettingsData, ctx)
+            }
+
+            fun ok(id: Int, nonce: Long?, result: ByteArray, signature: ResponseSigner.Signature?, upstreamSettingsData: Upstream.UpstreamSettingsData?, ctx: ValidCallContext<ParsedCallDetails>?, final: FinalizationData?): CallResult {
+                return CallResult(id, nonce, result, null, signature, upstreamSettingsData, ctx, null, final)
             }
 
             fun ok(id: Int, nonce: Long?, result: ByteArray, signature: ResponseSigner.Signature?, upstreamSettingsData: Upstream.UpstreamSettingsData?, ctx: ValidCallContext<ParsedCallDetails>?, stream: Flux<Chunk>?): CallResult {

--- a/src/main/kotlin/io/emeraldpay/dshackle/rpc/StreamHead.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/rpc/StreamHead.kt
@@ -23,7 +23,6 @@ import io.emeraldpay.dshackle.Chain
 import io.emeraldpay.dshackle.data.BlockContainer
 import io.emeraldpay.dshackle.upstream.Multistream
 import io.emeraldpay.dshackle.upstream.MultistreamHolder
-import io.emeraldpay.dshackle.upstream.finalization.toProtoLowerBoundType
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundData
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/io/emeraldpay/dshackle/rpc/StreamHead.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/rpc/StreamHead.kt
@@ -64,7 +64,7 @@ class StreamHead(
                 }
         val finalizationData =
             ms.getFinalizations().map {
-                BlockchainOuterClass.FinalizationData.newBuilder()
+                Common.FinalizationData.newBuilder()
                     .setHeight(it.height)
                     .setType(it.type.toProtoFinalizationType())
                     .build()

--- a/src/main/kotlin/io/emeraldpay/dshackle/startup/configure/GenericUpstreamCreator.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/startup/configure/GenericUpstreamCreator.kt
@@ -84,7 +84,7 @@ open class GenericUpstreamCreator(
             cs::upstreamRpcModulesDetector,
             buildMethodsFun,
             cs::lowerBoundService,
-            cs::finalizationDetectorBuilder
+            cs::finalizationDetectorBuilder,
         )
 
         upstream.start()

--- a/src/main/kotlin/io/emeraldpay/dshackle/startup/configure/GenericUpstreamCreator.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/startup/configure/GenericUpstreamCreator.kt
@@ -84,6 +84,7 @@ open class GenericUpstreamCreator(
             cs::upstreamRpcModulesDetector,
             buildMethodsFun,
             cs::lowerBoundService,
+            cs::finalizationDetectorBuilder
         )
 
         upstream.start()

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ChainResponse.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ChainResponse.kt
@@ -34,7 +34,7 @@ class ChainResponse @JvmOverloads constructor(
      */
     val providedSignature: ResponseSigner.Signature? = null,
     val resolvedUpstreamData: Upstream.UpstreamSettingsData? = null,
-    val finalization: FinalizationData? = null
+    val finalization: FinalizationData? = null,
 ) {
 
     constructor(stream: Flux<Chunk>, id: Int) :

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ChainResponse.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ChainResponse.kt
@@ -18,12 +18,13 @@ package io.emeraldpay.dshackle.upstream
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
 import io.emeraldpay.dshackle.upstream.signature.ResponseSigner
 import io.emeraldpay.dshackle.upstream.stream.Chunk
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-class ChainResponse(
+class ChainResponse @JvmOverloads constructor(
     private val result: ByteArray?,
     val error: ChainCallError?,
     val id: Id,
@@ -33,15 +34,18 @@ class ChainResponse(
      */
     val providedSignature: ResponseSigner.Signature? = null,
     val resolvedUpstreamData: Upstream.UpstreamSettingsData? = null,
+    val finalization: FinalizationData? = null
 ) {
 
     constructor(stream: Flux<Chunk>, id: Int) :
-        this(null, null, NumberId(id.toLong()), stream, null, null)
+        this(null, null, NumberId(id.toLong()), stream, null, null, null)
 
-    constructor(result: ByteArray?, error: ChainCallError?) : this(result, error, NumberId(0), null)
+    constructor(result: ByteArray?, error: ChainCallError?) : this(result, error, NumberId(0), null, null)
 
     constructor(result: ByteArray?, error: ChainCallError?, resolvedUpstreamData: Upstream.UpstreamSettingsData?) :
-        this(result, error, NumberId(0), null, null, resolvedUpstreamData)
+        this(result, error, NumberId(0), null, null, resolvedUpstreamData, null)
+    constructor(result: ByteArray?, resolvedUpstreamData: Upstream.UpstreamSettingsData?, finalization: FinalizationData) :
+        this(result, null, NumberId(0), null, null, resolvedUpstreamData, finalization)
 
     companion object {
         private val NULL_VALUE = "null".toByteArray()

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
@@ -366,6 +366,10 @@ abstract class Multistream(
             }.toList().map { FinalizationData(it.second, it.first) }
     }
 
+    override fun addFinalization(finalization: FinalizationData, upstreamId: String) {
+        getAll().find { it.getId() == upstreamId }?.addFinalization(finalization, upstreamId)
+    }
+
     override fun getLowerBounds(): Collection<LowerBoundData> {
         return lowerBounds.values
     }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
@@ -32,6 +32,8 @@ import io.emeraldpay.dshackle.startup.UpstreamChangeEvent
 import io.emeraldpay.dshackle.upstream.calls.AggregatedCallMethods
 import io.emeraldpay.dshackle.upstream.calls.CallMethods
 import io.emeraldpay.dshackle.upstream.calls.CallSelector
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationType
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundData
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
 import io.micrometer.core.instrument.Gauge
@@ -48,6 +50,7 @@ import reactor.core.publisher.Sinks
 import reactor.core.scheduler.Scheduler
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.max
 
 /**
  * Aggregation of multiple upstreams responding to a single blockchain
@@ -353,6 +356,14 @@ abstract class Multistream(
         observeUpstreamsStatuses()
 
         started = true
+    }
+
+    override fun getFinalizations(): Collection<FinalizationData> {
+        return getAll().flatMap { it.getFinalizations() }
+            .fold(mutableMapOf<FinalizationType, Long>()) { acc, data ->
+                acc[data.type] = max(acc[data.type] ?: 0, data.height)
+                acc
+            }.toList().map { FinalizationData(it.second, it.first) }
     }
 
     override fun getLowerBounds(): Collection<LowerBoundData> {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Selector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Selector.kt
@@ -220,12 +220,16 @@ class Selector {
         companion object {
             @JvmStatic
             val default = Sort(compareBy { null })
-            val safe = Sort(compareByDescending { up ->
-                up.getFinalizations().find { it.type == FinalizationType.SAFE_BLOCK }?.height ?: 0L
-            })
-            val finalized = Sort(compareByDescending { up ->
-                up.getFinalizations().find { it.type == FinalizationType.FINALIZED_BLOCK }?.height ?: 0L
-            })
+            val safe = Sort(
+                compareByDescending { up ->
+                    up.getFinalizations().find { it.type == FinalizationType.SAFE_BLOCK }?.height ?: 0L
+                },
+            )
+            val finalized = Sort(
+                compareByDescending { up ->
+                    up.getFinalizations().find { it.type == FinalizationType.FINALIZED_BLOCK }?.height ?: 0L
+                },
+            )
         }
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Selector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Selector.kt
@@ -79,17 +79,8 @@ class Selector {
                         },
                     )
 
-                    is Safe -> Sort(
-                        compareByDescending { up ->
-                            up.getFinalizations().find { it.type == FinalizationType.SAFE_BLOCK }?.height ?: 0L
-                        },
-                    )
-
-                    is Finalized -> Sort(
-                        compareByDescending { up ->
-                            up.getFinalizations().find { it.type == FinalizationType.FINALIZED_BLOCK }?.height ?: 0L
-                        },
-                    )
+                    is Safe -> Sort.safe
+                    is Finalized -> Sort.finalized
 
                     else -> Sort.default
                 }
@@ -229,6 +220,12 @@ class Selector {
         companion object {
             @JvmStatic
             val default = Sort(compareBy { null })
+            val safe = Sort(compareByDescending { up ->
+                up.getFinalizations().find { it.type == FinalizationType.SAFE_BLOCK }?.height ?: 0L
+            })
+            val finalized = Sort(compareByDescending { up ->
+                up.getFinalizations().find { it.type == FinalizationType.FINALIZED_BLOCK }?.height ?: 0L
+            })
         }
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Selector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Selector.kt
@@ -65,30 +65,30 @@ class Selector {
                     }
                 }
             }
-            class Number(val num: Long): HeightNumberOrTag()
-            object Pending: HeightNumberOrTag()
-            object Latest: HeightNumberOrTag()
-            object Safe: HeightNumberOrTag()
-            object Finalized: HeightNumberOrTag()
+            class Number(val num: Long) : HeightNumberOrTag()
+            object Pending : HeightNumberOrTag()
+            object Latest : HeightNumberOrTag()
+            object Safe : HeightNumberOrTag()
+            object Finalized : HeightNumberOrTag()
 
             fun getSort(): Sort {
                 return when (this) {
                     is Latest -> Sort(
                         compareByDescending {
                             it.getHead().getCurrentHeight()
-                        }
+                        },
                     )
 
                     is Safe -> Sort(
                         compareByDescending { up ->
                             up.getFinalizations().find { it.type == FinalizationType.SAFE_BLOCK }?.height ?: 0L
-                        }
+                        },
                     )
 
                     is Finalized -> Sort(
                         compareByDescending { up ->
                             up.getFinalizations().find { it.type == FinalizationType.FINALIZED_BLOCK }?.height ?: 0L
-                        }
+                        },
                     )
 
                     else -> Sort.default
@@ -109,7 +109,6 @@ class Selector {
                                 is HeightNumberOrTag.Number -> HeightMatcher(selector.num)
                                 else -> empty
                             }
-
                         }
                         else -> empty
                     }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Upstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Upstream.kt
@@ -21,6 +21,7 @@ import io.emeraldpay.dshackle.foundation.ChainOptions
 import io.emeraldpay.dshackle.reader.ChainReader
 import io.emeraldpay.dshackle.startup.UpstreamChangeEvent
 import io.emeraldpay.dshackle.upstream.calls.CallMethods
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundData
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
 import reactor.core.publisher.Flux
@@ -49,6 +50,9 @@ interface Upstream : Lifecycle {
     fun isGrpc(): Boolean
     fun getLowerBounds(): Collection<LowerBoundData>
     fun getLowerBound(lowerBoundType: LowerBoundType): LowerBoundData?
+
+    fun getFinalizations(): Collection<FinalizationData>
+
     fun getUpstreamSettingsData(): UpstreamSettingsData?
     fun updateLowerBound(lowerBound: Long, type: LowerBoundType)
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Upstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Upstream.kt
@@ -50,9 +50,8 @@ interface Upstream : Lifecycle {
     fun isGrpc(): Boolean
     fun getLowerBounds(): Collection<LowerBoundData>
     fun getLowerBound(lowerBoundType: LowerBoundType): LowerBoundData?
-
     fun getFinalizations(): Collection<FinalizationData>
-
+    fun addFinalization(finalization: FinalizationData, upstreamId: String)
     fun getUpstreamSettingsData(): UpstreamSettingsData?
     fun updateLowerBound(lowerBound: Long, type: LowerBoundType)
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/bitcoin/BitcoinRpcUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/bitcoin/BitcoinRpcUpstream.kt
@@ -86,6 +86,9 @@ open class BitcoinRpcUpstream(
         return emptyList()
     }
 
+    override fun addFinalization(finalization: FinalizationData, upstreamId: String) {
+    }
+
     override fun getUpstreamSettingsData(): Upstream.UpstreamSettingsData? {
         return null
     }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/bitcoin/BitcoinRpcUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/bitcoin/BitcoinRpcUpstream.kt
@@ -28,6 +28,7 @@ import io.emeraldpay.dshackle.upstream.Lifecycle
 import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.UpstreamAvailability
 import io.emeraldpay.dshackle.upstream.calls.CallMethods
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundData
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
 import reactor.core.Disposable
@@ -79,6 +80,10 @@ open class BitcoinRpcUpstream(
 
     override fun getLowerBound(lowerBoundType: LowerBoundType): LowerBoundData? {
         return null
+    }
+
+    override fun getFinalizations(): Collection<FinalizationData> {
+        return emptyList()
     }
 
     override fun getUpstreamSettingsData(): Upstream.UpstreamSettingsData? {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumCachingReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumCachingReader.kt
@@ -32,7 +32,6 @@ import io.emeraldpay.dshackle.reader.CompoundReader
 import io.emeraldpay.dshackle.reader.Reader
 import io.emeraldpay.dshackle.reader.RekeyingReader
 import io.emeraldpay.dshackle.reader.SpannedReader
-import io.emeraldpay.dshackle.reader.TransformingReader
 import io.emeraldpay.dshackle.upstream.CachingReader
 import io.emeraldpay.dshackle.upstream.Multistream
 import io.emeraldpay.dshackle.upstream.calls.CallMethods

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumCachingReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumCachingReader.kt
@@ -45,7 +45,6 @@ import io.emeraldpay.dshackle.upstream.ethereum.json.BlockJson
 import io.emeraldpay.dshackle.upstream.ethereum.json.TransactionJsonSnapshot
 import io.emeraldpay.dshackle.upstream.ethereum.json.TransactionLogJson
 import io.emeraldpay.dshackle.upstream.ethereum.json.TransactionRefJson
-import io.emeraldpay.dshackle.upstream.finalization.FinalizationType
 import org.apache.commons.collections4.Factory
 import org.springframework.cloud.sleuth.Tracer
 import reactor.core.publisher.Mono

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumChainSpecific.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumChainSpecific.kt
@@ -25,6 +25,7 @@ import io.emeraldpay.dshackle.upstream.ethereum.subscribe.AggregatedPendingTxes
 import io.emeraldpay.dshackle.upstream.ethereum.subscribe.EthereumWsIngressSubscription
 import io.emeraldpay.dshackle.upstream.ethereum.subscribe.NoPendingTxes
 import io.emeraldpay.dshackle.upstream.ethereum.subscribe.PendingTxesSource
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationDetector
 import io.emeraldpay.dshackle.upstream.generic.AbstractPollChainSpecific
 import io.emeraldpay.dshackle.upstream.generic.CachingReaderBuilder
 import io.emeraldpay.dshackle.upstream.generic.GenericUpstream
@@ -101,7 +102,14 @@ object EthereumChainSpecific : AbstractPollChainSpecific() {
         return EthereumLowerBoundService(chain, upstream)
     }
 
-    override fun upstreamSettingsDetector(chain: Chain, upstream: Upstream): UpstreamSettingsDetector {
+    override fun finalizationDetectorBuilder(): FinalizationDetector {
+        return EthereumFinalizationDetector()
+    }
+
+    override fun upstreamSettingsDetector(
+        chain: Chain,
+        upstream: Upstream,
+    ): UpstreamSettingsDetector {
         return EthereumUpstreamSettingsDetector(upstream, chain)
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumDirectReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumDirectReader.kt
@@ -32,6 +32,7 @@ import io.emeraldpay.dshackle.upstream.ethereum.json.TransactionReceiptJson
 import io.emeraldpay.dshackle.upstream.ethereum.json.TransactionRefJson
 import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcException
 import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcResponseError
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationType
 import io.emeraldpay.dshackle.upstream.rpcclient.ListParams
 import org.apache.commons.collections4.Factory
 import org.apache.commons.lang3.exception.ExceptionUtils
@@ -66,6 +67,7 @@ class EthereumDirectReader(
     val balanceReader: Reader<Address, Result<Wei>>
     val receiptReader: Reader<TransactionId, Result<ByteArray>>
     val logsByHashReader: Reader<BlockId, Result<List<TransactionLogJson>>>
+    val blockByFinalizationReader: Reader<FinalizationType, Result<BlockContainer>>
 
     init {
         blockReader = object : Reader<BlockHash, Result<BlockContainer>> {
@@ -105,6 +107,24 @@ class EthereumDirectReader(
                     }
             }
         }
+
+        blockByFinalizationReader = object : Reader<FinalizationType, Result<BlockContainer>> {
+            override fun read(key: FinalizationType): Mono<Result<BlockContainer>> {
+                val request = ChainRequest("eth_getBlockByNumber", ListParams(key.toBlockRef(), false))
+                val tag = when(key) {
+                    FinalizationType.FINALIZED_BLOCK -> Selector.Companion.HeightNumberOrTag.Finalized
+                    FinalizationType.SAFE_BLOCK -> Selector.Companion.HeightNumberOrTag.Safe
+                    else -> null
+                }
+                return readBlock(
+                    request,
+                    key.toString(),
+                    Selector.empty,
+                    tag?.getSort() ?: Selector.Sort.default
+                )
+            }
+        }
+
         balanceReader = object : Reader<Address, Result<Wei>> {
             override fun read(key: Address): Mono<Result<Wei>> {
                 val height = up.getHead().getCurrentHeight()?.let { HexQuantity.from(it).toHex() } ?: "latest"
@@ -194,8 +214,9 @@ class EthereumDirectReader(
         request: ChainRequest,
         id: String,
         matcher: Selector.Matcher = Selector.empty,
+        sort: Selector.Sort = Selector.Sort.default
     ): Mono<Result<BlockContainer>> {
-        return readWithQuorum(request, matcher)
+        return readWithQuorum(request, matcher, sort)
             .timeout(Duration.ofSeconds(5), Mono.error(TimeoutException("Block not read $id")))
             .retryWhen(Retry.fixedDelay(3, Duration.ofMillis(200)))
             .flatMap { result ->
@@ -227,6 +248,7 @@ class EthereumDirectReader(
     private fun readWithQuorum(
         request: ChainRequest,
         matcher: Selector.Matcher = Selector.empty,
+        sort: Selector.Sort = Selector.Sort.default
     ): Mono<Result<ByteArray>> {
         return Mono.just(requestReaderFactory)
             .map {
@@ -237,7 +259,7 @@ class EthereumDirectReader(
                 it.create(
                     RequestReaderFactory.ReaderData(
                         up,
-                        Selector.UpstreamFilter(requestMatcher),
+                        Selector.UpstreamFilter(sort, requestMatcher),
                         callMethodsFactory.create().createQuorumFor(request.method),
                         null,
                         tracer,

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumDirectReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumDirectReader.kt
@@ -111,7 +111,7 @@ class EthereumDirectReader(
         blockByFinalizationReader = object : Reader<FinalizationType, Result<BlockContainer>> {
             override fun read(key: FinalizationType): Mono<Result<BlockContainer>> {
                 val request = ChainRequest("eth_getBlockByNumber", ListParams(key.toBlockRef(), false))
-                val tag = when(key) {
+                val tag = when (key) {
                     FinalizationType.FINALIZED_BLOCK -> Selector.Companion.HeightNumberOrTag.Finalized
                     FinalizationType.SAFE_BLOCK -> Selector.Companion.HeightNumberOrTag.Safe
                     else -> null
@@ -120,7 +120,7 @@ class EthereumDirectReader(
                     request,
                     key.toString(),
                     Selector.empty,
-                    tag?.getSort() ?: Selector.Sort.default
+                    tag?.getSort() ?: Selector.Sort.default,
                 )
             }
         }
@@ -214,7 +214,7 @@ class EthereumDirectReader(
         request: ChainRequest,
         id: String,
         matcher: Selector.Matcher = Selector.empty,
-        sort: Selector.Sort = Selector.Sort.default
+        sort: Selector.Sort = Selector.Sort.default,
     ): Mono<Result<BlockContainer>> {
         return readWithQuorum(request, matcher, sort)
             .timeout(Duration.ofSeconds(5), Mono.error(TimeoutException("Block not read $id")))
@@ -248,7 +248,7 @@ class EthereumDirectReader(
     private fun readWithQuorum(
         request: ChainRequest,
         matcher: Selector.Matcher = Selector.empty,
-        sort: Selector.Sort = Selector.Sort.default
+        sort: Selector.Sort = Selector.Sort.default,
     ): Mono<Result<ByteArray>> {
         return Mono.just(requestReaderFactory)
             .map {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumFinalizationDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumFinalizationDetector.kt
@@ -43,7 +43,7 @@ class EthereumFinalizationDetector : FinalizationDetector {
                         ChainRequest(
                             "eth_getBlockByNumber",
                             ListParams("finalized", false),
-                            1,
+                            2,
                         ),
                     ),
                 ),

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumFinalizationDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumFinalizationDetector.kt
@@ -64,12 +64,18 @@ class EthereumFinalizationDetector : FinalizationDetector {
                         }
                     }
             }.doOnNext {
-                data[it.type] = it
+                addFinalization(it)
             }.onErrorResume {
                 log.error("Error during retrieving — $it")
                 Flux.empty()
             }
         }
+    }
+
+    override fun addFinalization(finalization: FinalizationData) {
+        data[finalization.type] = maxOf(data[finalization.type], finalization) { a, b ->
+            ((a?.height ?: 0) - (b?.height ?: 0)).toInt()
+        } ?: finalization
     }
 
     override fun getFinalizations(): Collection<FinalizationData> {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumFinalizationDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumFinalizationDetector.kt
@@ -27,7 +27,12 @@ class EthereumFinalizationDetector : FinalizationDetector {
         upstream: Upstream,
         blockTime: Duration,
     ): Flux<FinalizationData> {
-        return Flux.interval(blockTime.coerceAtLeast(Duration.ofSeconds(1)).multipliedBy(6)).flatMap {
+        val timer =
+            Flux.merge(
+                Flux.just(1),
+                Flux.interval(blockTime.coerceAtLeast(Duration.ofSeconds(1)).multipliedBy(6)),
+            )
+        return timer.flatMap {
             Flux.fromIterable(
                 listOf(
                     Pair(

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumFinalizationDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumFinalizationDetector.kt
@@ -1,0 +1,78 @@
+package io.emeraldpay.dshackle.upstream.ethereum
+
+import io.emeraldpay.dshackle.Global
+import io.emeraldpay.dshackle.upstream.ChainRequest
+import io.emeraldpay.dshackle.upstream.Upstream
+import io.emeraldpay.dshackle.upstream.ethereum.json.BlockJson
+import io.emeraldpay.dshackle.upstream.ethereum.json.TransactionRefJson
+import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcException
+import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcResponseError
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationDetector
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationType
+import io.emeraldpay.dshackle.upstream.rpcclient.ListParams
+import org.slf4j.LoggerFactory
+import reactor.core.publisher.Flux
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+class EthereumFinalizationDetector : FinalizationDetector {
+    companion object {
+        private val log = LoggerFactory.getLogger(EthereumFinalizationDetector::class.java)
+    }
+
+    val data: ConcurrentHashMap<FinalizationType, FinalizationData> = ConcurrentHashMap()
+
+    override fun detectFinalization(
+        upstream: Upstream,
+        blockTime: Duration,
+    ): Flux<FinalizationData> {
+        return Flux.interval(blockTime.coerceAtLeast(Duration.ofSeconds(1)).multipliedBy(6)).flatMap {
+            Flux.fromIterable(
+                listOf(
+                    Pair(
+                        FinalizationType.SAFE_BLOCK,
+                        ChainRequest(
+                            "eth_getBlockByNumber",
+                            ListParams("safe", false),
+                            1,
+                        ),
+                    ),
+                    Pair(
+                        FinalizationType.FINALIZED_BLOCK,
+                        ChainRequest(
+                            "eth_getBlockByNumber",
+                            ListParams("finalized", false),
+                            1,
+                        ),
+                    ),
+                ),
+            ).flatMap { (type, req) ->
+                upstream
+                    .getIngressReader()
+                    .read(req)
+                    .flatMap {
+                        it.requireResult().map { result ->
+                            val block =
+                                Global.objectMapper
+                                    .readValue(result, BlockJson::class.java) as BlockJson<TransactionRefJson>?
+                            if (block != null) {
+                                FinalizationData(block.number, type)
+                            } else {
+                                throw RpcException(RpcResponseError.CODE_INVALID_JSON, "can't parse block data")
+                            }
+                        }
+                    }
+            }.doOnNext {
+                data[it.type] = it
+            }.onErrorResume {
+                log.error("Error during retrieving — $it")
+                Flux.empty()
+            }
+        }
+    }
+
+    override fun getFinalizations(): Collection<FinalizationData> {
+        return data.values
+    }
+}

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReader.kt
@@ -15,7 +15,6 @@
  */
 package io.emeraldpay.dshackle.upstream.ethereum
 
-import io.emeraldpay.dshackle.Global.Companion.nullValue
 import io.emeraldpay.dshackle.data.BlockId
 import io.emeraldpay.dshackle.data.TxId
 import io.emeraldpay.dshackle.reader.ChainReader
@@ -23,7 +22,6 @@ import io.emeraldpay.dshackle.upstream.ChainRequest
 import io.emeraldpay.dshackle.upstream.ChainResponse
 import io.emeraldpay.dshackle.upstream.Head
 import io.emeraldpay.dshackle.upstream.LogsOracle
-import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.calls.CallMethods
 import io.emeraldpay.dshackle.upstream.ethereum.hex.HexQuantity
 import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcException
@@ -32,7 +30,6 @@ import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
 import io.emeraldpay.dshackle.upstream.finalization.FinalizationType
 import io.emeraldpay.dshackle.upstream.rpcclient.ListParams
 import reactor.core.publisher.Mono
-import reactor.kotlin.core.publisher.switchIfEmpty
 import java.math.BigInteger
 
 /**
@@ -170,7 +167,7 @@ class EthereumLocalReader(
                 blockRef == "pending" -> {
                     return null
                 }
-                blockRef == "finalized" || blockRef == "safe" ->  {
+                blockRef == "finalized" || blockRef == "safe" -> {
                     val type = FinalizationType.fromBlockRef(blockRef)
                     return reader.directReader
                         .blockByFinalizationReader.read(type)

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReader.kt
@@ -28,6 +28,8 @@ import io.emeraldpay.dshackle.upstream.calls.CallMethods
 import io.emeraldpay.dshackle.upstream.ethereum.hex.HexQuantity
 import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcException
 import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcResponseError
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationType
 import io.emeraldpay.dshackle.upstream.rpcclient.ListParams
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.switchIfEmpty
@@ -59,12 +61,7 @@ class EthereumLocalReader(
             // we do not want to serve any requests (except hardcoded) that have nonces from cache
             return Mono.empty()
         }
-        val common = commonRequests(key)
-            ?.switchIfEmpty { Mono.just(nullValue to null) }
-        if (common != null) {
-            return common.map { ChainResponse(it.first, null, it.second) }
-        }
-        return Mono.empty()
+        return commonRequests(key) ?: Mono.empty()
     }
 
     /**
@@ -72,7 +69,7 @@ class EthereumLocalReader(
      * parses JSON into Map. But the purpose of further processing and caching for some of the requests we want
      * to have actual data types.
      */
-    fun commonRequests(key: ChainRequest): Mono<Pair<ByteArray, Upstream.UpstreamSettingsData?>>? {
+    fun commonRequests(key: ChainRequest): Mono<ChainResponse>? {
         val method = key.method
         val params = key.params
         if (params is ListParams) {
@@ -89,7 +86,7 @@ class EthereumLocalReader(
                     }
                     reader.txByHashAsCont()
                         .read(hash)
-                        .map { it.data.json!! to it.resolvedUpstreamData }
+                        .map { ChainResponse(it.data.json, null, it.resolvedUpstreamData) }
                 }
 
                 method == "eth_getBlockByHash" -> {
@@ -106,7 +103,9 @@ class EthereumLocalReader(
                     if (withTx) {
                         null
                     } else {
-                        reader.blocksByIdAsCont().read(hash).map { it.data.json!! to it.resolvedUpstreamData }
+                        reader.blocksByIdAsCont().read(hash).map {
+                            ChainResponse(it.data.json, null, it.resolvedUpstreamData)
+                        }
                     }
                 }
 
@@ -126,7 +125,7 @@ class EthereumLocalReader(
                     }
                     reader.receipts()
                         .read(hash)
-                        .map { it.data to it.resolvedUpstreamData }
+                        .map { ChainResponse(it.data, null, it.resolvedUpstreamData) }
                 }
 
                 method == "drpc_getLogsEstimate" -> {
@@ -139,7 +138,7 @@ class EthereumLocalReader(
         return null
     }
 
-    fun getBlockByNumber(params: List<Any?>): Mono<Pair<ByteArray, Upstream.UpstreamSettingsData?>>? {
+    fun getBlockByNumber(params: List<Any?>): Mono<ChainResponse>? {
         if (params.size != 2 || params[0] == null || params[1] == null) {
             throw RpcException(RpcResponseError.CODE_INVALID_METHOD_PARAMS, "Must provide 2 parameters")
         }
@@ -168,8 +167,16 @@ class EthereumLocalReader(
                 blockRef == "earliest" -> {
                     number = 0
                 }
-                blockRef == "finalized" || blockRef == "safe" || blockRef == "pending" -> {
+                blockRef == "pending" -> {
                     return null
+                }
+                blockRef == "finalized" || blockRef == "safe" ->  {
+                    val type = FinalizationType.fromBlockRef(blockRef)
+                    return reader.directReader
+                        .blockByFinalizationReader.read(type)
+                        .map {
+                            ChainResponse(it.data.json, it.resolvedUpstreamData, FinalizationData(it.data.height, type))
+                        }
                 }
                 else -> {
                     throw RpcException(RpcResponseError.CODE_INVALID_METHOD_PARAMS, "Block number is invalid")
@@ -180,10 +187,10 @@ class EthereumLocalReader(
         }
 
         return reader.blocksByHeightAsCont()
-            .read(number).map { it.data.json!! to it.resolvedUpstreamData }
+            .read(number).map { ChainResponse(it.data.json, null, it.resolvedUpstreamData) }
     }
 
-    fun getLogsEstimate(params: List<Any?>): Mono<Pair<ByteArray, Upstream.UpstreamSettingsData?>>? {
+    fun getLogsEstimate(params: List<Any?>): Mono<ChainResponse>? {
         if (logsOracle == null) {
             throw NotImplementedError()
         }
@@ -234,7 +241,7 @@ class EthereumLocalReader(
         }
 
         return logsOracle.estimate(limit?.toLong(), fromBlock, toBlock, address, topics)
-            .map { it.toByteArray() to null }
+            .map { ChainResponse(it.toByteArray(), null, null) }
     }
 
     private fun parseBlockRef(blockRef: String?): Long {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReader.kt
@@ -15,6 +15,8 @@
  */
 package io.emeraldpay.dshackle.upstream.ethereum
 
+import io.emeraldpay.api.proto.Common.Chain
+import io.emeraldpay.dshackle.Global.Companion.nullValue
 import io.emeraldpay.dshackle.data.BlockId
 import io.emeraldpay.dshackle.data.TxId
 import io.emeraldpay.dshackle.reader.ChainReader
@@ -30,6 +32,7 @@ import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
 import io.emeraldpay.dshackle.upstream.finalization.FinalizationType
 import io.emeraldpay.dshackle.upstream.rpcclient.ListParams
 import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.switchIfEmpty
 import java.math.BigInteger
 
 /**
@@ -58,7 +61,11 @@ class EthereumLocalReader(
             // we do not want to serve any requests (except hardcoded) that have nonces from cache
             return Mono.empty()
         }
-        return commonRequests(key) ?: Mono.empty()
+        return commonRequests(key)?.switchIfEmpty {
+            // we need to explicitly return null to prevent executeOnRemote
+            // for example
+            Mono.just(ChainResponse(nullValue, null,null))
+        } ?: Mono.empty()
     }
 
     /**

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReader.kt
@@ -15,7 +15,6 @@
  */
 package io.emeraldpay.dshackle.upstream.ethereum
 
-import io.emeraldpay.api.proto.Common.Chain
 import io.emeraldpay.dshackle.Global.Companion.nullValue
 import io.emeraldpay.dshackle.data.BlockId
 import io.emeraldpay.dshackle.data.TxId
@@ -64,7 +63,7 @@ class EthereumLocalReader(
         return commonRequests(key)?.switchIfEmpty {
             // we need to explicitly return null to prevent executeOnRemote
             // for example
-            Mono.just(ChainResponse(nullValue, null,null))
+            Mono.just(ChainResponse(nullValue, null, null))
         } ?: Mono.empty()
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReader.kt
@@ -176,8 +176,8 @@ class EthereumLocalReader(
                 }
                 blockRef == "finalized" || blockRef == "safe" -> {
                     val type = FinalizationType.fromBlockRef(blockRef)
-                    return reader.directReader
-                        .blockByFinalizationReader.read(type)
+                    return reader
+                        .blockByFinalization().read(type)
                         .map {
                             ChainResponse(it.data.json, it.resolvedUpstreamData, FinalizationData(it.data.height, type))
                         }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationData.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationData.kt
@@ -5,7 +5,18 @@ import io.emeraldpay.api.proto.BlockchainOuterClass
 class FinalizationData(
     val height: Long,
     val type: FinalizationType,
-)
+) {
+
+    override fun toString(): String {
+        return "FinalizationData($height, ${type.toBlockRef()})"
+    }
+    override fun equals(other: Any?): Boolean {
+        return when (other) {
+            is FinalizationData -> other.height == height && other.type == type
+            else -> false
+        }
+    }
+}
 
 enum class FinalizationType {
     UNKNOWN,

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationData.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationData.kt
@@ -1,6 +1,5 @@
 package io.emeraldpay.dshackle.upstream.finalization
 
-import io.emeraldpay.api.proto.BlockchainOuterClass
 import io.emeraldpay.api.proto.Common
 
 class FinalizationData(

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationData.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationData.kt
@@ -31,7 +31,7 @@ enum class FinalizationType {
         }
     }
 
-    fun toBlockRef(): String{
+    fun toBlockRef(): String {
         return when (this) {
             FINALIZED_BLOCK -> "finalized"
             SAFE_BLOCK -> "safe"

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationData.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationData.kt
@@ -11,13 +11,32 @@ enum class FinalizationType {
     UNKNOWN,
     SAFE_BLOCK,
     FINALIZED_BLOCK,
-}
+    ;
 
-fun FinalizationType.toProtoFinalizationType(): BlockchainOuterClass.FinalizationType {
-    return when (this) {
-        FinalizationType.FINALIZED_BLOCK -> BlockchainOuterClass.FinalizationType.FINALIZATION_FINALIZED_BLOCK
-        FinalizationType.UNKNOWN -> BlockchainOuterClass.FinalizationType.UNRECOGNIZED
-        FinalizationType.SAFE_BLOCK -> BlockchainOuterClass.FinalizationType.FINALIZATION_SAFE_BLOCK
+    companion object {
+        fun fromBlockRef(v: String): FinalizationType {
+            return when (v) {
+                "safe" -> SAFE_BLOCK
+                "finalized" -> FINALIZED_BLOCK
+                else -> UNKNOWN
+            }
+        }
+    }
+
+    fun toProtoFinalizationType(): BlockchainOuterClass.FinalizationType {
+        return when (this) {
+            FINALIZED_BLOCK -> BlockchainOuterClass.FinalizationType.FINALIZATION_FINALIZED_BLOCK
+            UNKNOWN -> BlockchainOuterClass.FinalizationType.UNRECOGNIZED
+            SAFE_BLOCK -> BlockchainOuterClass.FinalizationType.FINALIZATION_SAFE_BLOCK
+        }
+    }
+
+    fun toBlockRef(): String{
+        return when (this) {
+            FINALIZED_BLOCK -> "finalized"
+            SAFE_BLOCK -> "safe"
+            UNKNOWN -> "unknown"
+        }
     }
 }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationData.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationData.kt
@@ -1,0 +1,31 @@
+package io.emeraldpay.dshackle.upstream.finalization
+
+import io.emeraldpay.api.proto.BlockchainOuterClass
+
+class FinalizationData(
+    val height: Long,
+    val type: FinalizationType,
+)
+
+enum class FinalizationType {
+    UNKNOWN,
+    SAFE_BLOCK,
+    FINALIZED_BLOCK,
+}
+
+fun FinalizationType.toProtoFinalizationType(): BlockchainOuterClass.FinalizationType {
+    return when (this) {
+        FinalizationType.FINALIZED_BLOCK -> BlockchainOuterClass.FinalizationType.FINALIZATION_FINALIZED_BLOCK
+        FinalizationType.UNKNOWN -> BlockchainOuterClass.FinalizationType.UNRECOGNIZED
+        FinalizationType.SAFE_BLOCK -> BlockchainOuterClass.FinalizationType.FINALIZATION_SAFE_BLOCK
+    }
+}
+
+fun BlockchainOuterClass.FinalizationType.fromProtoType(): FinalizationType {
+    return when (this) {
+        BlockchainOuterClass.FinalizationType.FINALIZATION_UNSPECIFIED -> FinalizationType.UNKNOWN
+        BlockchainOuterClass.FinalizationType.FINALIZATION_SAFE_BLOCK -> FinalizationType.SAFE_BLOCK
+        BlockchainOuterClass.FinalizationType.FINALIZATION_FINALIZED_BLOCK -> FinalizationType.FINALIZED_BLOCK
+        BlockchainOuterClass.FinalizationType.UNRECOGNIZED -> FinalizationType.UNKNOWN
+    }
+}

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationData.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationData.kt
@@ -1,6 +1,7 @@
 package io.emeraldpay.dshackle.upstream.finalization
 
 import io.emeraldpay.api.proto.BlockchainOuterClass
+import io.emeraldpay.api.proto.Common
 
 class FinalizationData(
     val height: Long,
@@ -34,11 +35,11 @@ enum class FinalizationType {
         }
     }
 
-    fun toProtoFinalizationType(): BlockchainOuterClass.FinalizationType {
+    fun toProtoFinalizationType(): Common.FinalizationType {
         return when (this) {
-            FINALIZED_BLOCK -> BlockchainOuterClass.FinalizationType.FINALIZATION_FINALIZED_BLOCK
-            UNKNOWN -> BlockchainOuterClass.FinalizationType.UNRECOGNIZED
-            SAFE_BLOCK -> BlockchainOuterClass.FinalizationType.FINALIZATION_SAFE_BLOCK
+            FINALIZED_BLOCK -> Common.FinalizationType.FINALIZATION_FINALIZED_BLOCK
+            UNKNOWN -> Common.FinalizationType.UNRECOGNIZED
+            SAFE_BLOCK -> Common.FinalizationType.FINALIZATION_SAFE_BLOCK
         }
     }
 
@@ -51,11 +52,11 @@ enum class FinalizationType {
     }
 }
 
-fun BlockchainOuterClass.FinalizationType.fromProtoType(): FinalizationType {
+fun Common.FinalizationType.fromProtoType(): FinalizationType {
     return when (this) {
-        BlockchainOuterClass.FinalizationType.FINALIZATION_UNSPECIFIED -> FinalizationType.UNKNOWN
-        BlockchainOuterClass.FinalizationType.FINALIZATION_SAFE_BLOCK -> FinalizationType.SAFE_BLOCK
-        BlockchainOuterClass.FinalizationType.FINALIZATION_FINALIZED_BLOCK -> FinalizationType.FINALIZED_BLOCK
-        BlockchainOuterClass.FinalizationType.UNRECOGNIZED -> FinalizationType.UNKNOWN
+        Common.FinalizationType.FINALIZATION_UNSPECIFIED -> FinalizationType.UNKNOWN
+        Common.FinalizationType.FINALIZATION_SAFE_BLOCK -> FinalizationType.SAFE_BLOCK
+        Common.FinalizationType.FINALIZATION_FINALIZED_BLOCK -> FinalizationType.FINALIZED_BLOCK
+        Common.FinalizationType.UNRECOGNIZED -> FinalizationType.UNKNOWN
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationDetector.kt
@@ -11,6 +11,8 @@ interface FinalizationDetector {
     ): Flux<FinalizationData>
 
     fun getFinalizations(): Collection<FinalizationData>
+
+    fun addFinalization(finalization: FinalizationData)
 }
 
 class NoopFinalizationDetector : FinalizationDetector {
@@ -23,5 +25,9 @@ class NoopFinalizationDetector : FinalizationDetector {
 
     override fun getFinalizations(): Collection<FinalizationData> {
         return emptyList()
+    }
+
+    override fun addFinalization(finalization: FinalizationData) {
+
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationDetector.kt
@@ -28,6 +28,5 @@ class NoopFinalizationDetector : FinalizationDetector {
     }
 
     override fun addFinalization(finalization: FinalizationData) {
-
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/finalization/FinalizationDetector.kt
@@ -1,0 +1,27 @@
+package io.emeraldpay.dshackle.upstream.finalization
+
+import io.emeraldpay.dshackle.upstream.Upstream
+import reactor.core.publisher.Flux
+import java.time.Duration
+
+interface FinalizationDetector {
+    fun detectFinalization(
+        upstream: Upstream,
+        blockTime: Duration,
+    ): Flux<FinalizationData>
+
+    fun getFinalizations(): Collection<FinalizationData>
+}
+
+class NoopFinalizationDetector : FinalizationDetector {
+    override fun detectFinalization(
+        upstream: Upstream,
+        blockTime: Duration,
+    ): Flux<FinalizationData> {
+        return Flux.empty()
+    }
+
+    override fun getFinalizations(): Collection<FinalizationData> {
+        return emptyList()
+    }
+}

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/AbstractChainSpecific.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/AbstractChainSpecific.kt
@@ -20,12 +20,13 @@ import io.emeraldpay.dshackle.upstream.UpstreamSettingsDetector
 import io.emeraldpay.dshackle.upstream.calls.CallMethods
 import io.emeraldpay.dshackle.upstream.calls.CallSelector
 import io.emeraldpay.dshackle.upstream.ethereum.WsSubscriptions
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationDetector
+import io.emeraldpay.dshackle.upstream.finalization.NoopFinalizationDetector
 import org.springframework.cloud.sleuth.Tracer
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Scheduler
 
 abstract class AbstractChainSpecific : ChainSpecific {
-
     override fun localReaderBuilder(
         cachingReader: CachingReader,
         methods: CallMethods,
@@ -35,11 +36,18 @@ abstract class AbstractChainSpecific : ChainSpecific {
         return Mono.just(LocalReader(methods))
     }
 
+    override fun finalizationDetectorBuilder(): FinalizationDetector {
+        return NoopFinalizationDetector()
+    }
+
     override fun makeCachingReaderBuilder(tracer: Tracer): CachingReaderBuilder {
         return { _, _, _ -> NoopCachingReader }
     }
 
-    override fun upstreamSettingsDetector(chain: Chain, upstream: Upstream): UpstreamSettingsDetector? {
+    override fun upstreamSettingsDetector(
+        chain: Chain,
+        upstream: Upstream,
+    ): UpstreamSettingsDetector? {
         return null
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/ChainSpecific.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/ChainSpecific.kt
@@ -32,6 +32,7 @@ import io.emeraldpay.dshackle.upstream.calls.CallSelector
 import io.emeraldpay.dshackle.upstream.cosmos.CosmosChainSpecific
 import io.emeraldpay.dshackle.upstream.ethereum.EthereumChainSpecific
 import io.emeraldpay.dshackle.upstream.ethereum.WsSubscriptions
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationDetector
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundService
 import io.emeraldpay.dshackle.upstream.near.NearChainSpecific
 import io.emeraldpay.dshackle.upstream.polkadot.PolkadotChainSpecific
@@ -45,6 +46,7 @@ import reactor.core.scheduler.Scheduler
 typealias SubscriptionBuilder = (Multistream) -> EgressSubscription
 typealias LocalReaderBuilder = (CachingReader, CallMethods, Head, LogsOracle?) -> Mono<ChainReader>
 typealias CachingReaderBuilder = (Multistream, Caches, Factory<CallMethods>) -> CachingReader
+typealias FinalizationDetectorBuilder = () -> FinalizationDetector
 
 interface ChainSpecific {
     fun getFromHeader(data: ByteArray, upstreamId: String, api: ChainReader): Mono<BlockContainer>
@@ -55,7 +57,14 @@ interface ChainSpecific {
 
     fun unsubscribeNewHeadsRequest(subId: String): ChainRequest
 
-    fun localReaderBuilder(cachingReader: CachingReader, methods: CallMethods, head: Head, logsOracle: LogsOracle?): Mono<ChainReader>
+    fun finalizationDetectorBuilder(): FinalizationDetector
+
+    fun localReaderBuilder(
+        cachingReader: CachingReader,
+        methods: CallMethods,
+        head: Head,
+        logsOracle: LogsOracle?,
+    ): Mono<ChainReader>
 
     fun subscriptionBuilder(headScheduler: Scheduler): (Multistream) -> EgressSubscription
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/GenericUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/GenericUpstream.kt
@@ -294,6 +294,12 @@ open class GenericUpstream(
         return finalizationDetector.getFinalizations()
     }
 
+    override fun addFinalization(finalization: FinalizationData, upstreamId: String) {
+        if (getId() == upstreamId) {
+            finalizationDetector.addFinalization(finalization)
+        }
+    }
+
     private fun detectFinalization() {
         finalizationDetectorSubscription =
             finalizationDetector.detectFinalization(this, chainConfig.expectedBlockTime).subscribe {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/GenericUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/GenericUpstream.kt
@@ -280,6 +280,8 @@ open class GenericUpstream(
         livenessSubscription = null
         lowerBlockDetectorSubscription?.dispose()
         lowerBlockDetectorSubscription = null
+        finalizationDetectorSubscription?.dispose()
+        finalizationDetectorSubscription = null
         connector.getHead().stop()
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/GenericUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/GenericUpstream.kt
@@ -23,6 +23,7 @@ import io.emeraldpay.dshackle.upstream.UpstreamValidator
 import io.emeraldpay.dshackle.upstream.UpstreamValidatorBuilder
 import io.emeraldpay.dshackle.upstream.ValidateUpstreamSettingsResult
 import io.emeraldpay.dshackle.upstream.calls.CallMethods
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
 import io.emeraldpay.dshackle.upstream.generic.connectors.ConnectorFactory
 import io.emeraldpay.dshackle.upstream.generic.connectors.GenericConnector
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundData
@@ -43,11 +44,12 @@ open class GenericUpstream(
     role: UpstreamsConfig.UpstreamRole,
     targets: CallMethods?,
     private val node: QuorumForLabels.QuorumItem?,
-    chainConfig: ChainsConfig.ChainConfig,
+    private val chainConfig: ChainsConfig.ChainConfig,
     connectorFactory: ConnectorFactory,
     validatorBuilder: UpstreamValidatorBuilder,
     upstreamSettingsDetectorBuilder: UpstreamSettingsDetectorBuilder,
     lowerBoundServiceBuilder: LowerBoundServiceBuilder,
+    finalizationDetectorBuilder: FinalizationDetectorBuilder,
 ) : DefaultUpstream(id, hash, null, UpstreamAvailability.OK, options, role, targets, node, chainConfig, chain), Lifecycle {
 
     constructor(
@@ -63,7 +65,8 @@ open class GenericUpstream(
         upstreamRpcModulesDetectorBuilder: UpstreamRpcModulesDetectorBuilder,
         buildMethods: (UpstreamsConfig.Upstream<*>, Chain) -> CallMethods,
         lowerBoundServiceBuilder: LowerBoundServiceBuilder,
-    ) : this(config.id!!, chain, hash, options, config.role, buildMethods(config, chain), node, chainConfig, connectorFactory, validatorBuilder, upstreamSettingsDetectorBuilder, lowerBoundServiceBuilder) {
+        finalizationDetectorBuilder: FinalizationDetectorBuilder,
+    ) : this(config.id!!, chain, hash, options, config.role, buildMethods(config, chain), node, chainConfig, connectorFactory, validatorBuilder, upstreamSettingsDetectorBuilder, lowerBoundServiceBuilder, finalizationDetectorBuilder) {
         rpcModulesDetector = upstreamRpcModulesDetectorBuilder(this)
         detectRpcModules(config, buildMethods)
     }
@@ -84,6 +87,9 @@ open class GenericUpstream(
     private val started = AtomicBoolean(false)
     private val isUpstreamValid = AtomicBoolean(false)
     private val clientVersion = AtomicReference(UNKNOWN_CLIENT_VERSION)
+
+    private val finalizationDetector = finalizationDetectorBuilder()
+    private var finalizationDetectorSubscription: Disposable? = null
 
     override fun getHead(): Head {
         return connector.getHead()
@@ -255,6 +261,8 @@ open class GenericUpstream(
         detectSettings()
 
         detectLowerBlock()
+
+        detectFinalization()
     }
 
     override fun stop() {
@@ -282,11 +290,23 @@ open class GenericUpstream(
         }
     }
 
-    private fun detectLowerBlock() {
-        lowerBlockDetectorSubscription = lowerBoundService.detectLowerBounds()
-            .subscribe {
+    override fun getFinalizations(): Collection<FinalizationData> {
+        return finalizationDetector.getFinalizations()
+    }
+
+    private fun detectFinalization() {
+        finalizationDetectorSubscription =
+            finalizationDetector.detectFinalization(this, chainConfig.expectedBlockTime).subscribe {
                 sendUpstreamStateEvent(UPDATED)
             }
+    }
+
+    private fun detectLowerBlock() {
+        lowerBlockDetectorSubscription =
+            lowerBoundService.detectLowerBounds()
+                .subscribe {
+                    sendUpstreamStateEvent(UPDATED)
+                }
     }
 
     fun getIngressSubscription(): IngressSubscription {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/BitcoinGrpcUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/BitcoinGrpcUpstream.kt
@@ -36,6 +36,7 @@ import io.emeraldpay.dshackle.upstream.UpstreamAvailability
 import io.emeraldpay.dshackle.upstream.bitcoin.BitcoinUpstream
 import io.emeraldpay.dshackle.upstream.bitcoin.ExtractBlock
 import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcException
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
 import io.emeraldpay.dshackle.upstream.forkchoice.MostWorkForkChoice
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundData
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
@@ -152,6 +153,10 @@ class BitcoinGrpcUpstream(
     }
 
     override fun getLowerBounds(): Collection<LowerBoundData> {
+        return emptyList()
+    }
+
+    override fun getFinalizations(): Collection<FinalizationData> {
         return emptyList()
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/BitcoinGrpcUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/BitcoinGrpcUpstream.kt
@@ -160,6 +160,9 @@ class BitcoinGrpcUpstream(
         return emptyList()
     }
 
+    override fun addFinalization(finalization: FinalizationData, upstreamId: String) {
+    }
+
     override fun getLowerBound(lowerBoundType: LowerBoundType): LowerBoundData? {
         return null
     }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/GenericGrpcUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/GenericGrpcUpstream.kt
@@ -35,6 +35,9 @@ import io.emeraldpay.dshackle.upstream.Lifecycle
 import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.calls.CallMethods
 import io.emeraldpay.dshackle.upstream.ethereum.domain.BlockHash
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationType
+import io.emeraldpay.dshackle.upstream.finalization.fromProtoType
 import io.emeraldpay.dshackle.upstream.forkchoice.NoChoiceWithPriorityForkChoice
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundData
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
@@ -74,52 +77,65 @@ open class GenericGrpcUpstream(
 ),
     GrpcUpstream,
     Lifecycle {
-
-    private val blockConverter: Function<BlockchainOuterClass.ChainHead, GrpcHead.GrpcHeadData> = Function { value ->
-        val parentHash =
-            if (value.parentBlockId.isBlank()) {
-                null
-            } else {
-                BlockId.from(BlockHash.from("0x" + value.parentBlockId))
-            }
-        val block = BlockContainer(
-            value.height,
-            BlockId.from(BlockHash.from("0x" + value.blockId)),
-            BigInteger(1, value.weight.toByteArray()),
-            Instant.ofEpochMilli(value.timestamp),
-            false,
-            null,
-            null,
-            parentHash,
-        )
-        val lowerBounds = value.lowerBoundsList
-            .map { LowerBoundData(it.lowerBoundValue, it.lowerBoundTimestamp, it.lowerBoundType.fromProtoType()) }
-        GrpcHead.GrpcHeadData(block, lowerBounds)
-    }
+    private val blockConverter: Function<BlockchainOuterClass.ChainHead, GrpcHead.GrpcHeadData> =
+        Function { value ->
+            val parentHash =
+                if (value.parentBlockId.isBlank()) {
+                    null
+                } else {
+                    BlockId.from(BlockHash.from("0x" + value.parentBlockId))
+                }
+            val block =
+                BlockContainer(
+                    value.height,
+                    BlockId.from(BlockHash.from("0x" + value.blockId)),
+                    BigInteger(1, value.weight.toByteArray()),
+                    Instant.ofEpochMilli(value.timestamp),
+                    false,
+                    null,
+                    null,
+                    parentHash,
+                )
+            val lowerBounds =
+                value.lowerBoundsList
+                    .map { LowerBoundData(it.lowerBoundValue, it.lowerBoundTimestamp, it.lowerBoundType.fromProtoType()) }
+            val finalizationData =
+                value.finalizationDataList.map {
+                    FinalizationData(it.height, it.type.fromProtoType())
+                }
+            GrpcHead.GrpcHeadData(block, lowerBounds, finalizationData)
+        }
 
     private val upstreamStatus = GrpcUpstreamStatus(overrideLabels)
-    private val grpcHead = GrpcHead(
-        getId(),
-        chain,
-        this,
-        remote,
-        blockConverter,
-        null,
-        NoChoiceWithPriorityForkChoice(nodeRating, parentId),
-        headScheduler,
-    )
+    private val grpcHead =
+        GrpcHead(
+            getId(),
+            chain,
+            this,
+            remote,
+            blockConverter,
+            null,
+            NoChoiceWithPriorityForkChoice(nodeRating, parentId),
+            headScheduler,
+        )
     private var capabilities: Set<Capability> = emptySet()
     private val buildInfo: BuildInfo = BuildInfo()
 
     private val defaultReader: ChainReader = client.getReader()
 
     private val lowerBounds = ConcurrentHashMap<LowerBoundType, LowerBoundData>()
+    private var finalizationData = ConcurrentHashMap<FinalizationType, FinalizationData>()
 
     override fun start() {
-        grpcHead.lowerBoundsFlux()
-            .publishOn(lowerBoundScheduler)
-            .subscribe {
-                lowerBounds[it.type] = it
+        grpcHead.rawDataFlux()
+            .publishOn(rawDataScheduler)
+            .subscribe { head ->
+                head.lowerBounds.forEach {
+                    lowerBounds[it.type] = it
+                }
+                head.finalizationData.forEach {
+                    finalizationData[it.type] = it
+                }
                 sendUpstreamStateEvent(UpstreamChangeEvent.ChangeType.UPDATED)
             }
     }
@@ -205,6 +221,10 @@ open class GenericGrpcUpstream(
         return lowerBounds[lowerBoundType]
     }
 
+    override fun getFinalizations(): Collection<FinalizationData> {
+        return finalizationData.values
+    }
+
     override fun getUpstreamSettingsData(): Upstream.UpstreamSettingsData? {
         return Upstream.UpstreamSettingsData(
             nodeId(),
@@ -214,8 +234,9 @@ open class GenericGrpcUpstream(
     }
 
     companion object {
-        val lowerBoundScheduler: Scheduler = Schedulers.fromExecutorService(
-            Executors.newFixedThreadPool(4, CustomizableThreadFactory("grpc-lower-bound-")),
-        )
+        val rawDataScheduler: Scheduler =
+            Schedulers.fromExecutorService(
+                Executors.newFixedThreadPool(4, CustomizableThreadFactory("grpc-raw-data-bound-")),
+            )
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/GenericGrpcUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/GenericGrpcUpstream.kt
@@ -225,6 +225,10 @@ open class GenericGrpcUpstream(
         return finalizationData.values
     }
 
+    override fun addFinalization(finalization: FinalizationData, upstreamId: String) {
+        finalizationData[finalization.type] = finalization
+    }
+
     override fun getUpstreamSettingsData(): Upstream.UpstreamSettingsData? {
         return Upstream.UpstreamSettingsData(
             nodeId(),

--- a/src/test/groovy/io/emeraldpay/dshackle/test/ApiReaderMock.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/test/ApiReaderMock.groovy
@@ -108,7 +108,7 @@ class ApiReaderMock implements Reader<ChainRequest, ChainResponse> {
                 }
                 error = new ChainCallError(-32601, "Method ${request.method} with ${request.params} is not mocked")
             }
-            return new ChainResponse(result, error, ChainResponse.Id.from(request.id), null, null, null)
+            return new ChainResponse(result, error, ChainResponse.Id.from(request.id), null, null, null, null)
         } as Callable<ChainResponse>
         return Mono.fromCallable(call)
     }

--- a/src/test/groovy/io/emeraldpay/dshackle/test/GenericUpstreamMock.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/test/GenericUpstreamMock.groovy
@@ -77,6 +77,7 @@ class GenericUpstreamMock extends GenericUpstream {
                 io.emeraldpay.dshackle.upstream.starknet.StarknetChainSpecific.INSTANCE.&validator,
                 io.emeraldpay.dshackle.upstream.starknet.StarknetChainSpecific.INSTANCE.&upstreamSettingsDetector,
                 io.emeraldpay.dshackle.upstream.starknet.StarknetChainSpecific.INSTANCE.&lowerBoundService,
+                io.emeraldpay.dshackle.upstream.starknet.StarknetChainSpecific.INSTANCE.&finalizationDetectorBuilder,
         )
         this.ethereumHeadMock = this.getHead() as EthereumHeadMock
         setLag(0)

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/FilteredApisSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/FilteredApisSpec.groovy
@@ -77,7 +77,8 @@ class FilteredApisSpec extends Specification {
                     connectorFactory,
                     cs.&validator,
                     cs.&upstreamSettingsDetector,
-                    cs.&lowerBoundService
+                    cs.&lowerBoundService,
+                    cs.&finalizationDetectorBuilder
             )
         }
         def matcher = new Selector.LabelMatcher("test", ["foo"])

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReaderSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReaderSpec.groovy
@@ -84,8 +84,8 @@ class EthereumLocalReaderSpec extends Specification {
         then:
         act != null
         with(act.block()) {
-            it.first.length > 0
-            with(Global.objectMapper.readValue(it.first, BlockJson)) {
+            it.result.length > 0
+            with(Global.objectMapper.readValue(it.result, BlockJson)) {
                 number == 101
             }
         }
@@ -112,8 +112,8 @@ class EthereumLocalReaderSpec extends Specification {
         then:
         act != null
         with(act.block()) {
-            it.first.length > 0
-            with(Global.objectMapper.readValue(it.first, BlockJson)) {
+            it.result.length > 0
+            with(Global.objectMapper.readValue(it.result, BlockJson)) {
                 number == 0
             }
         }
@@ -140,8 +140,8 @@ class EthereumLocalReaderSpec extends Specification {
         then:
         act != null
         with(act.block()) {
-            it.first.length > 0
-            with(Global.objectMapper.readValue(it.first, BlockJson)) {
+            it.result.length > 0
+            with(Global.objectMapper.readValue(it.result, BlockJson)) {
                 number == 74735
             }
         }

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/grpc/GrpcHeadSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/grpc/GrpcHeadSpec.groovy
@@ -60,7 +60,7 @@ class GrpcHeadSpec extends Specification {
             }
         })
         def convert = { BlockchainOuterClass.ChainHead head ->
-            new GrpcHead.GrpcHeadData(TestingCommons.blockForBitcoin(head.height), List.of())
+            new GrpcHead.GrpcHeadData(TestingCommons.blockForBitcoin(head.height), List.of(), List.of())
         }
         def head = new GrpcHead(
                 "test",
@@ -127,7 +127,7 @@ class GrpcHeadSpec extends Specification {
             }
         })
         def convert = { BlockchainOuterClass.ChainHead head ->
-            new GrpcHead.GrpcHeadData(TestingCommons.blockForBitcoin(head.height), List.of())
+            new GrpcHead.GrpcHeadData(TestingCommons.blockForBitcoin(head.height), List.of(), List.of())
         }
         def head = new GrpcHead(
                 "test",

--- a/src/test/kotlin/io/emeraldpay/dshackle/upstream/SelectorTest.kt
+++ b/src/test/kotlin/io/emeraldpay/dshackle/upstream/SelectorTest.kt
@@ -1,6 +1,10 @@
 package io.emeraldpay.dshackle.upstream
 
 import io.emeraldpay.api.proto.BlockchainOuterClass
+import io.emeraldpay.api.proto.BlockchainOuterClass.BlockTag
+import io.emeraldpay.api.proto.BlockchainOuterClass.HeightSelector
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationType
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundData
 import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -49,6 +53,94 @@ class SelectorTest {
 
         assertEquals(
             listOf(up1, up2, up3, up4),
+            actual,
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("finalData")
+    fun `sort with finalization`(
+        finalizationType: FinalizationType,
+        finalizationProto: BlockchainOuterClass.BlockTag
+    ) {
+        val up1 = mock<Upstream> {
+            on { getFinalizations() } doReturn listOf(FinalizationData(1L, finalizationType))
+        }
+        val up2 = mock<Upstream> {
+            on { getFinalizations() } doReturn listOf(FinalizationData(10L, finalizationType))
+        }
+        val up3 = mock<Upstream> {
+            on { getFinalizations() } doReturn listOf(FinalizationData(100L, finalizationType))
+        }
+        val up4 = mock<Upstream> {
+            on { getFinalizations() } doReturn listOf()
+        }
+        val ups = listOf(up4, up3, up2, up1)
+        val requestSelectors = listOf(
+            BlockchainOuterClass.Selector.newBuilder()
+                .setHeightSelector(
+                    HeightSelector.newBuilder()
+                        .setTag(finalizationProto)
+                )
+                .build(),
+        )
+
+        val upstreamFilter = Selector.convertToUpstreamFilter(requestSelectors)
+
+        val actual = ups.sortedWith(upstreamFilter.sort.comparator)
+
+        assertEquals(
+            listOf(up3, up2, up1, up4),
+            actual,
+        )
+    }
+
+    @Test
+    fun `sort with latest`() {
+        val mockHead1 = mock<Head> {
+            on { getCurrentHeight() } doReturn 1L
+        }
+        val up1 = mock<Upstream> {
+            on { getHead() } doReturn mockHead1
+        }
+
+        val mockHead2 = mock<Head> {
+            on { getCurrentHeight() } doReturn 2L
+        }
+        val up2 = mock<Upstream> {
+            on { getHead() } doReturn mockHead2
+        }
+
+        val mockHead3 = mock<Head> {
+            on { getCurrentHeight() } doReturn 3L
+        }
+        val up3 = mock<Upstream> {
+            on { getHead() } doReturn mockHead3
+        }
+
+        val mockHead4 = mock<Head> {
+            on { getCurrentHeight() } doReturn null
+        }
+        val up4 = mock<Upstream> {
+            on { getHead() } doReturn mockHead4
+        }
+
+        val ups = listOf(up2, up1, up4, up3)
+        val requestSelectors = listOf(
+            BlockchainOuterClass.Selector.newBuilder()
+                .setHeightSelector(
+                    HeightSelector.newBuilder()
+                        .setTag(BlockTag.LATEST)
+                )
+                .build(),
+        )
+
+        val upstreamFilter = Selector.convertToUpstreamFilter(requestSelectors)
+
+        val actual = ups.sortedWith(upstreamFilter.sort.comparator)
+
+        assertEquals(
+            listOf(up3, up2, up1, up4),
             actual,
         )
     }
@@ -126,6 +218,12 @@ class SelectorTest {
                 of(LowerBoundType.STATE, BlockchainOuterClass.LowerBoundType.LOWER_BOUND_STATE),
                 of(LowerBoundType.BLOCK, BlockchainOuterClass.LowerBoundType.LOWER_BOUND_BLOCK),
                 of(LowerBoundType.SLOT, BlockchainOuterClass.LowerBoundType.LOWER_BOUND_SLOT),
+            )
+        @JvmStatic
+        fun finalData(): List<Arguments> =
+            listOf(
+                of(FinalizationType.SAFE_BLOCK, BlockTag.SAFE),
+                of(FinalizationType.FINALIZED_BLOCK, BlockTag.FINALIZED),
             )
     }
 }

--- a/src/test/kotlin/io/emeraldpay/dshackle/upstream/SelectorTest.kt
+++ b/src/test/kotlin/io/emeraldpay/dshackle/upstream/SelectorTest.kt
@@ -61,7 +61,7 @@ class SelectorTest {
     @MethodSource("finalData")
     fun `sort with finalization`(
         finalizationType: FinalizationType,
-        finalizationProto: BlockchainOuterClass.BlockTag
+        finalizationProto: BlockchainOuterClass.BlockTag,
     ) {
         val up1 = mock<Upstream> {
             on { getFinalizations() } doReturn listOf(FinalizationData(1L, finalizationType))
@@ -80,7 +80,7 @@ class SelectorTest {
             BlockchainOuterClass.Selector.newBuilder()
                 .setHeightSelector(
                     HeightSelector.newBuilder()
-                        .setTag(finalizationProto)
+                        .setTag(finalizationProto),
                 )
                 .build(),
         )
@@ -130,7 +130,7 @@ class SelectorTest {
             BlockchainOuterClass.Selector.newBuilder()
                 .setHeightSelector(
                     HeightSelector.newBuilder()
-                        .setTag(BlockTag.LATEST)
+                        .setTag(BlockTag.LATEST),
                 )
                 .build(),
         )
@@ -219,6 +219,7 @@ class SelectorTest {
                 of(LowerBoundType.BLOCK, BlockchainOuterClass.LowerBoundType.LOWER_BOUND_BLOCK),
                 of(LowerBoundType.SLOT, BlockchainOuterClass.LowerBoundType.LOWER_BOUND_SLOT),
             )
+
         @JvmStatic
         fun finalData(): List<Arguments> =
             listOf(

--- a/src/test/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumFinalizationDetectorTest.kt
+++ b/src/test/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumFinalizationDetectorTest.kt
@@ -13,7 +13,8 @@ import io.emeraldpay.dshackle.upstream.rpcclient.ListParams
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import reactor.core.publisher.Mono
 import java.time.Duration
 import java.time.Instant
@@ -34,21 +35,34 @@ class EthereumFinalizationDetectorTest {
 
     @Test
     fun testDetectFinalization() {
-
-        `when`(chainReader.read(ChainRequest("eth_getBlockByNumber", ListParams("safe", false),1)))
-            .thenReturn(Mono.just(ChainResponse(Global.objectMapper.writeValueAsString(
-                BlockJson<TransactionRefJson>().apply {
-                    number = 1
-                    timestamp = Instant.now()
-                }
-            ).toByteArray(), null)))
+        `when`(chainReader.read(ChainRequest("eth_getBlockByNumber", ListParams("safe", false), 1)))
+            .thenReturn(
+                Mono.just(
+                    ChainResponse(
+                        Global.objectMapper.writeValueAsString(
+                            BlockJson<TransactionRefJson>().apply {
+                                number = 1
+                                timestamp = Instant.now()
+                            },
+                        ).toByteArray(),
+                        null,
+                    ),
+                ),
+            )
         `when`(chainReader.read(ChainRequest("eth_getBlockByNumber", ListParams("finalized", false), 2)))
-            .thenReturn(Mono.just(ChainResponse(Global.objectMapper.writeValueAsString(
-                BlockJson<TransactionRefJson>().apply {
-                    number = 2
-                    timestamp = Instant.now()
-                }
-            ).toByteArray(), null)))
+            .thenReturn(
+                Mono.just(
+                    ChainResponse(
+                        Global.objectMapper.writeValueAsString(
+                            BlockJson<TransactionRefJson>().apply {
+                                number = 2
+                                timestamp = Instant.now()
+                            },
+                        ).toByteArray(),
+                        null,
+                    ),
+                ),
+            )
 
         val flux = detector.detectFinalization(upstream, Duration.ofMillis(200))
         flux.take(2).collectList().block()

--- a/src/test/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumFinalizationDetectorTest.kt
+++ b/src/test/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumFinalizationDetectorTest.kt
@@ -1,0 +1,61 @@
+package io.emeraldpay.dshackle.upstream.ethereum
+
+import io.emeraldpay.dshackle.Global
+import io.emeraldpay.dshackle.reader.ChainReader
+import io.emeraldpay.dshackle.upstream.ChainRequest
+import io.emeraldpay.dshackle.upstream.ChainResponse
+import io.emeraldpay.dshackle.upstream.Upstream
+import io.emeraldpay.dshackle.upstream.ethereum.json.BlockJson
+import io.emeraldpay.dshackle.upstream.ethereum.json.TransactionRefJson
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationType
+import io.emeraldpay.dshackle.upstream.rpcclient.ListParams
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import reactor.core.publisher.Mono
+import java.time.Duration
+import java.time.Instant
+
+class EthereumFinalizationDetectorTest {
+
+    private lateinit var upstream: Upstream
+    private lateinit var chainReader: ChainReader
+    private lateinit var detector: EthereumFinalizationDetector
+
+    @BeforeEach
+    fun setUp() {
+        upstream = mock()
+        chainReader = mock()
+        `when`(upstream.getIngressReader()).thenReturn(chainReader)
+        detector = EthereumFinalizationDetector()
+    }
+
+    @Test
+    fun testDetectFinalization() {
+
+        `when`(chainReader.read(ChainRequest("eth_getBlockByNumber", ListParams("safe", false),1)))
+            .thenReturn(Mono.just(ChainResponse(Global.objectMapper.writeValueAsString(
+                BlockJson<TransactionRefJson>().apply {
+                    number = 1
+                    timestamp = Instant.now()
+                }
+            ).toByteArray(), null)))
+        `when`(chainReader.read(ChainRequest("eth_getBlockByNumber", ListParams("finalized", false), 2)))
+            .thenReturn(Mono.just(ChainResponse(Global.objectMapper.writeValueAsString(
+                BlockJson<TransactionRefJson>().apply {
+                    number = 2
+                    timestamp = Instant.now()
+                }
+            ).toByteArray(), null)))
+
+        val flux = detector.detectFinalization(upstream, Duration.ofMillis(200))
+        flux.take(2).collectList().block()
+        val result = detector.getFinalizations().toList()
+        Assertions.assertEquals(2, result.size)
+        org.assertj.core.api.Assertions.assertThat(result)
+            .contains(FinalizationData(2L, FinalizationType.FINALIZED_BLOCK))
+            .contains(FinalizationData(1L, FinalizationType.SAFE_BLOCK))
+    }
+}

--- a/src/test/kotlin/io/emeraldpay/dshackle/upstream/grpc/GenericGrpcUpstreamTest.kt
+++ b/src/test/kotlin/io/emeraldpay/dshackle/upstream/grpc/GenericGrpcUpstreamTest.kt
@@ -1,0 +1,121 @@
+package io.emeraldpay.dshackle.upstream.grpc
+
+import com.google.protobuf.ByteString
+import io.emeraldpay.api.proto.BlockchainGrpc
+import io.emeraldpay.api.proto.BlockchainOuterClass
+import io.emeraldpay.api.proto.Common
+import io.emeraldpay.dshackle.Chain
+import io.emeraldpay.dshackle.config.ChainsConfig
+import io.emeraldpay.dshackle.config.UpstreamsConfig
+import io.emeraldpay.dshackle.test.MockGrpcServerKt
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationData
+import io.emeraldpay.dshackle.upstream.finalization.FinalizationType
+import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundData
+import io.emeraldpay.dshackle.upstream.lowerbound.LowerBoundType
+import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcGrpcClient
+import io.grpc.stub.StreamObserver
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import reactor.core.publisher.Sinks
+import reactor.core.scheduler.Schedulers
+
+class GenericGrpcUpstreamTest {
+    private val parentId = "testParent"
+    private val hash: Byte = 0x01
+    private val role = UpstreamsConfig.UpstreamRole.PRIMARY
+    private val headSink = Sinks.many().multicast().directBestEffort<BlockchainOuterClass.ChainHead>()
+    private val remote =
+        MockGrpcServerKt().clientForServer(
+            object : BlockchainGrpc.BlockchainImplBase() {
+                override fun subscribeHead(
+                    request: Common.Chain,
+                    responseObserver: StreamObserver<BlockchainOuterClass.ChainHead>,
+                ) {
+                    Thread {
+                        headSink.asFlux().subscribe { data ->
+                            responseObserver.onNext(data)
+                            Thread.sleep(500)
+                        }
+                    }.start()
+                }
+            },
+        )
+    private val client = Mockito.mock(JsonRpcGrpcClient::class.java)
+    private val nodeRating = 5
+    private val overrideLabels = Mockito.mock(UpstreamsConfig.Labels::class.java)
+    private val headScheduler = Schedulers.single()
+
+    private fun getUpstream(): GrpcUpstream {
+        return GenericGrpcUpstream(
+            parentId,
+            hash,
+            role,
+            Chain.LINEA__MAINNET,
+            remote,
+            client,
+            nodeRating,
+            overrideLabels,
+            ChainsConfig.ChainConfig.default(),
+            headScheduler,
+        )
+    }
+
+    @Test
+    fun start() {
+        val up = getUpstream()
+        up.getHead().start()
+        up.start()
+        headSink.emitNext(
+            BlockchainOuterClass.ChainHead.newBuilder()
+                .setChain(Common.ChainRef.CHAIN_LINEA__MAINNET)
+                .setHeight(10L)
+                .setWeight(ByteString.EMPTY)
+                .setBlockId("a2622ec25e883dd13c1091c18ba717a1a794713baa77b8e68ec6a993045cb50f")
+                .setTimestamp(0)
+                .addAllFinalizationData(
+                    mutableListOf(
+                        BlockchainOuterClass
+                            .FinalizationData
+                            .newBuilder()
+                            .setType(BlockchainOuterClass.FinalizationType.FINALIZATION_FINALIZED_BLOCK)
+                            .setHeight(8L)
+                            .build(),
+                    ),
+                )
+                .addAllLowerBounds(
+                    mutableListOf(
+                        BlockchainOuterClass.LowerBound
+                            .newBuilder()
+                            .setLowerBoundType(BlockchainOuterClass.LowerBoundType.LOWER_BOUND_TX)
+                            .setLowerBoundTimestamp(0)
+                            .setLowerBoundValue(1L).build(),
+                    ),
+                )
+                .build(),
+        ) { _, _ ->
+            true
+        }
+        Thread.sleep(100)
+        Assertions.assertEquals(1, up.getFinalizations().size)
+        Assertions.assertTrue(up.getFinalizations()
+            .contains(FinalizationData(8L, FinalizationType.FINALIZED_BLOCK)))
+        Assertions.assertTrue(up.getLowerBounds()
+            .contains(LowerBoundData(1L, 0L, LowerBoundType.TX)))
+    }
+
+    @Test
+    fun getFinalizations() {
+        val up = getUpstream()
+        val finalizationData1 = FinalizationData(100L, FinalizationType.FINALIZED_BLOCK)
+
+        val finalizationData2 = FinalizationData(200L, FinalizationType.FINALIZED_BLOCK)
+
+        up.addFinalization(finalizationData1, "upstream1")
+        up.addFinalization(finalizationData2, "upstream2")
+
+        val finalizations = up.getFinalizations()
+        Assertions.assertEquals(1, finalizations.size)
+        Assertions.assertTrue(finalizations.contains(finalizationData2))
+    }
+}

--- a/src/test/kotlin/io/emeraldpay/dshackle/upstream/grpc/GenericGrpcUpstreamTest.kt
+++ b/src/test/kotlin/io/emeraldpay/dshackle/upstream/grpc/GenericGrpcUpstreamTest.kt
@@ -75,10 +75,10 @@ class GenericGrpcUpstreamTest {
                 .setTimestamp(0)
                 .addAllFinalizationData(
                     mutableListOf(
-                        BlockchainOuterClass
+                        Common
                             .FinalizationData
                             .newBuilder()
-                            .setType(BlockchainOuterClass.FinalizationType.FINALIZATION_FINALIZED_BLOCK)
+                            .setType(Common.FinalizationType.FINALIZATION_FINALIZED_BLOCK)
                             .setHeight(8L)
                             .build(),
                     ),

--- a/src/test/kotlin/io/emeraldpay/dshackle/upstream/grpc/GenericGrpcUpstreamTest.kt
+++ b/src/test/kotlin/io/emeraldpay/dshackle/upstream/grpc/GenericGrpcUpstreamTest.kt
@@ -98,10 +98,14 @@ class GenericGrpcUpstreamTest {
         }
         Thread.sleep(100)
         Assertions.assertEquals(1, up.getFinalizations().size)
-        Assertions.assertTrue(up.getFinalizations()
-            .contains(FinalizationData(8L, FinalizationType.FINALIZED_BLOCK)))
-        Assertions.assertTrue(up.getLowerBounds()
-            .contains(LowerBoundData(1L, 0L, LowerBoundType.TX)))
+        Assertions.assertTrue(
+            up.getFinalizations()
+                .contains(FinalizationData(8L, FinalizationType.FINALIZED_BLOCK)),
+        )
+        Assertions.assertTrue(
+            up.getLowerBounds()
+                .contains(LowerBoundData(1L, 0L, LowerBoundType.TX)),
+        )
     }
 
     @Test

--- a/src/test/kotlin/test/MockGrpcServerKt.kt
+++ b/src/test/kotlin/test/MockGrpcServerKt.kt
@@ -32,7 +32,7 @@ class MockGrpcServerKt {
         val serverName = InProcessServerBuilder.generateName()
         grpcCleanup.register(
             InProcessServerBuilder
-                .forName(serverName).directExecutor().addService(impl).build().start()
+                .forName(serverName).directExecutor().addService(impl).build().start(),
         )
         val channel = grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build())
         return ReactorBlockchainGrpc.newReactorStub(channel)

--- a/src/test/kotlin/test/MockGrpcServerKt.kt
+++ b/src/test/kotlin/test/MockGrpcServerKt.kt
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2019 ETCDEV GmbH
+ * Copyright (c) 2020 EmeraldPay, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.emeraldpay.dshackle.test
+
+import io.emeraldpay.api.proto.BlockchainGrpc
+import io.emeraldpay.api.proto.ReactorBlockchainGrpc
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import io.grpc.testing.GrpcCleanupRule
+import org.junit.Rule
+
+class MockGrpcServerKt {
+
+    @get:Rule
+    val grpcCleanup = GrpcCleanupRule()
+
+    fun clientForServer(impl: BlockchainGrpc.BlockchainImplBase): ReactorBlockchainGrpc.ReactorBlockchainStub {
+        val serverName = InProcessServerBuilder.generateName()
+        grpcCleanup.register(
+            InProcessServerBuilder
+                .forName(serverName).directExecutor().addService(impl).build().start()
+        )
+        val channel = grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build())
+        return ReactorBlockchainGrpc.newReactorStub(channel)
+    }
+}


### PR DESCRIPTION
- New type of data tracked for upstream: finalization data
- Implement finalization tracking for Etherum-like networks
- Refactor height matcher protobuf to have clear blocknumber or tag type
- Send safe/finalized blocks through LocalReader and return data in API