### PR TITLE
Pass all upstreams that resolved a request

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/BaseHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/BaseHandler.kt
@@ -116,7 +116,7 @@ abstract class BaseHandler(
                             // If Proxy is configured to preserve original order it means that a client expect responses at exact same position
                             // as requests even if a request completely failed for a some reason. It's very unlikely situation, but still possible
                             // At this case, if we found a gap in responses, we put a default response with an error
-                            ?: NativeCall.CallResult(id, null, null, NativeCall.CallError(id, "No response", null, null), null, null, null)
+                            ?: NativeCall.CallResult(id, null, null, NativeCall.CallError(id, "No response", null, null), null, emptyList(), null)
                     }
                 }
                 .flatMapMany {

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/WebsocketHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/WebsocketHandler.kt
@@ -183,7 +183,7 @@ class WebsocketHandler(
                 }
                 Mono.just(response)
                     .map { Global.objectMapper.writeValueAsString(it) }
-                    .doOnNext { eventHandler.onResponse(NativeCall.CallResult.ok(0, null, it.toByteArray(), null, null, null)) }
+                    .doOnNext { eventHandler.onResponse(NativeCall.CallResult.ok(0, null, it.toByteArray(), null, emptyList(), null)) }
                     .doFinally { eventHandler.close() }
             } else {
                 val eventHandler: AccessHandlerHttp.RequestHandler = eventHandlerFactory.call()

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/QuorumRequestReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/QuorumRequestReader.kt
@@ -223,8 +223,12 @@ class QuorumRequestReader(
         }
     }
 
-    private fun resolvedBy() =
-        if (quorum.getResolvedBy().isEmpty()) null else quorum.getResolvedBy().last().getUpstreamSettingsData()
+    private fun resolvedBy(): List<Upstream.UpstreamSettingsData> {
+        if (quorum.getResolvedBy().isEmpty()) {
+            return emptyList()
+        }
+        return quorum.getResolvedBy().last().getUpstreamSettingsData()?.run { listOf(this) } ?: emptyList()
+    }
 
     private fun noResponse(method: String, q: CallQuorum): Mono<Result> {
         return apiControl.upstreamsMatchesResponse()?.run {
@@ -232,7 +236,7 @@ class QuorumRequestReader(
             val cause = getCause(method) ?: return Mono.error(RpcException(1, "No response for method $method", getFullCause()))
             if (cause.shouldReturnNull) {
                 Mono.just(
-                    Result(Global.nullValue, null, 1, null, null),
+                    Result(Global.nullValue, null, 1, emptyList(), null),
                 )
             } else {
                 Mono.error(RpcException(1, "No response for method $method. Cause - ${cause.cause}"))

--- a/src/main/kotlin/io/emeraldpay/dshackle/reader/RequestReaderFactory.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/reader/RequestReaderFactory.kt
@@ -34,9 +34,12 @@ abstract class RequestReader(
             )
         }
 
-    protected fun handleError(error: ChainCallError?, id: Int, upstreamSettingsData: Upstream.UpstreamSettingsData?) =
-        error?.asException(ChainResponse.NumberId(id), upstreamSettingsData)
-            ?: ChainException(ChainResponse.NumberId(id), ChainCallError(-32603, "Unhandled Upstream error"), upstreamSettingsData)
+    protected fun handleError(
+        error: ChainCallError?,
+        id: Int,
+        upstreamSettingsData: List<Upstream.UpstreamSettingsData>,
+    ) = error?.asException(ChainResponse.NumberId(id), upstreamSettingsData)
+        ?: ChainException(ChainResponse.NumberId(id), ChainCallError(-32603, "Unhandled Upstream error"), upstreamSettingsData)
 
     protected fun getSignature(key: ChainRequest, response: ChainResponse, upstreamId: String) =
         response.providedSignature
@@ -50,7 +53,7 @@ abstract class RequestReader(
         val value: ByteArray,
         val signature: ResponseSigner.Signature?,
         val quorum: Int,
-        val resolvedUpstreamData: Upstream.UpstreamSettingsData?,
+        val resolvedUpstreamData: List<Upstream.UpstreamSettingsData>,
         val stream: Flux<Chunk>?,
     )
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ChainCallError.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ChainCallError.kt
@@ -36,7 +36,7 @@ data class ChainCallError(val code: Int, val message: String, val details: Any?)
         return ChainCallUpstreamException(id ?: ChainResponse.NumberId(-1), this)
     }
 
-    fun asException(id: ChainResponse.Id?, upstreamSettingsData: Upstream.UpstreamSettingsData?): ChainException {
+    fun asException(id: ChainResponse.Id?, upstreamSettingsData: List<Upstream.UpstreamSettingsData>): ChainException {
         return ChainException(id ?: ChainResponse.NumberId(-1), this, upstreamSettingsData, false)
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ChainCallUpstreamException.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ChainCallUpstreamException.kt
@@ -3,4 +3,4 @@ package io.emeraldpay.dshackle.upstream
 class ChainCallUpstreamException(
     id: ChainResponse.Id,
     error: ChainCallError,
-) : ChainException(id, error, null, false)
+) : ChainException(id, error, emptyList(), false)

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ChainException.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ChainException.kt
@@ -20,7 +20,7 @@ import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcException
 open class ChainException(
     val id: ChainResponse.Id,
     val error: ChainCallError,
-    val upstreamSettingsData: Upstream.UpstreamSettingsData? = null,
+    val upstreamSettingsData: List<Upstream.UpstreamSettingsData> = emptyList(),
     writableStackTrace: Boolean = true,
     cause: Throwable? = null,
 ) : Exception(error.message, cause, true, writableStackTrace) {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ChainResponse.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ChainResponse.kt
@@ -33,18 +33,18 @@ class ChainResponse @JvmOverloads constructor(
      * When making a request through Dshackle protocol a remote may provide its signature with the response, which we keep here
      */
     val providedSignature: ResponseSigner.Signature? = null,
-    val resolvedUpstreamData: Upstream.UpstreamSettingsData? = null,
+    val resolvedUpstreamData: List<Upstream.UpstreamSettingsData> = emptyList(),
     val finalization: FinalizationData? = null,
 ) {
 
     constructor(stream: Flux<Chunk>, id: Int) :
-        this(null, null, NumberId(id.toLong()), stream, null, null, null)
+        this(null, null, NumberId(id.toLong()), stream, null, emptyList(), null)
 
     constructor(result: ByteArray?, error: ChainCallError?) : this(result, error, NumberId(0), null, null)
 
-    constructor(result: ByteArray?, error: ChainCallError?, resolvedUpstreamData: Upstream.UpstreamSettingsData?) :
+    constructor(result: ByteArray?, error: ChainCallError?, resolvedUpstreamData: List<Upstream.UpstreamSettingsData>) :
         this(result, error, NumberId(0), null, null, resolvedUpstreamData, null)
-    constructor(result: ByteArray?, resolvedUpstreamData: Upstream.UpstreamSettingsData?, finalization: FinalizationData) :
+    constructor(result: ByteArray?, resolvedUpstreamData: List<Upstream.UpstreamSettingsData>, finalization: FinalizationData) :
         this(result, null, NumberId(0), null, null, resolvedUpstreamData, finalization)
 
     companion object {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumCachingReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumCachingReader.kt
@@ -157,7 +157,7 @@ open class EthereumCachingReader(
     ) : Reader<K, Result<D>> {
         override fun read(key: K): Mono<Result<D>> {
             return reader.read(key)
-                .map { Result(it, null) }
+                .map { Result(it, emptyList()) }
         }
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumDirectReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumDirectReader.kt
@@ -274,6 +274,6 @@ class EthereumDirectReader(
 
     data class Result<T>(
         val data: T,
-        val resolvedUpstreamData: Upstream.UpstreamSettingsData?,
+        val resolvedUpstreamData: List<Upstream.UpstreamSettingsData>,
     )
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReader.kt
@@ -63,7 +63,7 @@ class EthereumLocalReader(
         return commonRequests(key)?.switchIfEmpty {
             // we need to explicitly return null to prevent executeOnRemote
             // for example
-            Mono.just(ChainResponse(nullValue, null, null))
+            Mono.just(ChainResponse(nullValue, null, emptyList()))
         } ?: Mono.empty()
     }
 
@@ -244,7 +244,7 @@ class EthereumLocalReader(
         }
 
         return logsOracle.estimate(limit?.toLong(), fromBlock, toBlock, address, topics)
-            .map { ChainResponse(it.toByteArray(), null, null) }
+            .map { ChainResponse(it.toByteArray(), null, emptyList()) }
     }
 
     private fun parseBlockRef(blockRef: String?): Long {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImpl.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImpl.kt
@@ -378,7 +378,7 @@ open class WsConnectionImpl(
                 RpcResponseError.CODE_INTERNAL_ERROR,
                 "Response not received from WebSocket",
             ),
-            null,
+            emptyList(),
             false,
         )
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/rpcclient/JsonRpcGrpcClient.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/rpcclient/JsonRpcGrpcClient.kt
@@ -127,7 +127,16 @@ class JsonRpcGrpcClient(
                 } else {
                     null
                 }
-                Mono.just(ChainResponse(bytes, null, ChainResponse.NumberId(0), null, signature, Upstream.UpstreamSettingsData(0, resp.upstreamId, resp.upstreamNodeVersion)))
+                Mono.just(
+                    ChainResponse(
+                        bytes,
+                        null,
+                        ChainResponse.NumberId(0),
+                        null,
+                        signature,
+                        listOf(Upstream.UpstreamSettingsData(0, resp.upstreamId, resp.upstreamNodeVersion)),
+                    ),
+                )
             } else {
                 metrics?.fails?.increment()
                 Mono.error(

--- a/src/test/groovy/io/emeraldpay/dshackle/proxy/BaseHandlerSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/proxy/BaseHandlerSpec.groovy
@@ -62,7 +62,7 @@ class BaseHandlerSpec extends Specification {
         def call = new ProxyCall(ProxyCall.RpcType.SINGLE)
         call.items.add(request)
         call.ids[0] = 5
-        def response = new NativeCall.CallResult(0, null, '{"foo": 1}'.bytes, null, null, null, null, null)
+        def response = new NativeCall.CallResult(0, null, '{"foo": 1}'.bytes, null, null, List.of(), null, null)
         when:
         def act = Flux.from(handler.execute(Chain.ETHEREUM__MAINNET, call, requestHandler, false))
                 .collectList()
@@ -85,7 +85,7 @@ class BaseHandlerSpec extends Specification {
         def call = new ProxyCall(ProxyCall.RpcType.BATCH)
         call.items.add(request)
         call.ids[0] = 5
-        def response = new NativeCall.CallResult(0, null, '{"foo": 1}'.bytes, null, null, null, null, null)
+        def response = new NativeCall.CallResult(0, null, '{"foo": 1}'.bytes, null, null, List.of(), null, null)
         when:
         def act = Flux.from(handler.execute(Chain.ETHEREUM__MAINNET, call, requestHandler, false))
                 .collectList()
@@ -116,8 +116,8 @@ class BaseHandlerSpec extends Specification {
         call.items.add(request2)
         call.ids[1] = 6
         def response = [
-                new NativeCall.CallResult(1, null, '{"foo": 2}'.bytes, null, null, null, null, null),
-                new NativeCall.CallResult(0, null, '{"foo": 1}'.bytes, null, null, null, null, null)
+                new NativeCall.CallResult(1, null, '{"foo": 2}'.bytes, null, null, List.of(), null, null),
+                new NativeCall.CallResult(0, null, '{"foo": 1}'.bytes, null, null, List.of(), null, null)
         ]
         when:
         def act = Flux.from(handler.execute(Chain.ETHEREUM__MAINNET, call, requestHandler, true))
@@ -149,8 +149,8 @@ class BaseHandlerSpec extends Specification {
         call.items.add(request2)
         call.ids[1] = 6
         def response = [
-                new NativeCall.CallResult(1, null, '{"foo": 2}'.bytes, null, null, null, null, null),
-                new NativeCall.CallResult(0, null, '{"foo": 1}'.bytes, null, null, null, null, null)
+                new NativeCall.CallResult(1, null, '{"foo": 2}'.bytes, null, null, List.of(), null, null),
+                new NativeCall.CallResult(0, null, '{"foo": 1}'.bytes, null, null, List.of(), null, null)
         ]
         when:
         def act = Flux.from(handler.execute(Chain.ETHEREUM__MAINNET, call, requestHandler, true))
@@ -189,8 +189,8 @@ class BaseHandlerSpec extends Specification {
 
         // note there is only 2 responses
         def response = [
-                new NativeCall.CallResult(1, null, '{"foo": 2}'.bytes, null, null, null, null, null),
-                new NativeCall.CallResult(2, null, '{"foo": 3}'.bytes, null, null, null, null, null)
+                new NativeCall.CallResult(1, null, '{"foo": 2}'.bytes, null, null, List.of(), null, null),
+                new NativeCall.CallResult(2, null, '{"foo": 3}'.bytes, null, null, List.of(), null, null)
         ]
         when:
         def act = Flux.from(handler.execute(Chain.ETHEREUM__MAINNET, call, requestHandler, true))

--- a/src/test/groovy/io/emeraldpay/dshackle/proxy/HttpHandlerSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/proxy/HttpHandlerSpec.groovy
@@ -42,7 +42,7 @@ class HttpHandlerSpec extends Specification {
                 .setMethod("test_test")
                 .setPayload(ByteString.copyFromUtf8("[]"))
                 .build()
-        def respItem = new NativeCall.CallResult(1, null, "100".bytes, null, null, null, null, null)
+        def respItem = new NativeCall.CallResult(1, null, "100".bytes, null, null, List.of(), null, null)
         def req = BlockchainOuterClass.NativeCallRequest.newBuilder()
                 .setChain(Common.ChainRef.CHAIN_ETHEREUM__MAINNET)
                 .addItems(reqItem)
@@ -128,7 +128,7 @@ class HttpHandlerSpec extends Specification {
         def act = handler.execute(Chain.ETHEREUM__MAINNET, call, new AccessHandlerHttp.NoOpHandler(), false)
 
         then:
-        1 * nativeCall.nativeCallResult(_) >> Flux.just(new NativeCall.CallResult(1, null, "".bytes, null, null, null, null, null))
+        1 * nativeCall.nativeCallResult(_) >> Flux.just(new NativeCall.CallResult(1, null, "".bytes, null, null, List.of(), null, null))
         StepVerifier.create(act)
                 .expectNext("hello")
                 .expectComplete()

--- a/src/test/groovy/io/emeraldpay/dshackle/proxy/WebsocketHandlerSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/proxy/WebsocketHandlerSpec.groovy
@@ -86,7 +86,7 @@ class WebsocketHandlerSpec extends Specification {
 
     def "Respond to a single call"() {
         setup:
-        def response = new NativeCall.CallResult(0, null, '{"foo": 1}'.bytes, null, null, new Upstream.UpstreamSettingsData("test"), null, null)
+        def response = new NativeCall.CallResult(0, null, '{"foo": 1}'.bytes, null, null, List.of(new Upstream.UpstreamSettingsData("test")), null, null)
 
         def nativeCall = Mock(NativeCall) {
             1 * it.nativeCallResult(_) >> Flux.fromIterable([response])

--- a/src/test/groovy/io/emeraldpay/dshackle/proxy/WriteRpcJsonSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/proxy/WriteRpcJsonSpec.groovy
@@ -85,7 +85,7 @@ class WriteRpcJsonSpec extends Specification {
         def call = new ProxyCall(ProxyCall.RpcType.SINGLE)
         call.ids[1] = 105
         def data = [
-                new NativeCall.CallResult(1, null, '"0x98dbb1"'.bytes, null, null, null, null, null)
+                new NativeCall.CallResult(1, null, '"0x98dbb1"'.bytes, null, null, List.of(), null, null)
         ]
         when:
         def act = writer.toJson(call, data[0])
@@ -98,7 +98,7 @@ class WriteRpcJsonSpec extends Specification {
         def call = new ProxyCall(ProxyCall.RpcType.SINGLE)
         call.ids[1] = 1
         def data = [
-                new NativeCall.CallResult(1, null, null, new NativeCall.CallError(1, "Internal Error", null, null, null), null, null, null, null)
+                new NativeCall.CallResult(1, null, null, new NativeCall.CallError(1, "Internal Error", null, null, List.of()), null, List.of(), null, null)
         ]
         when:
         def act = writer.toJson(call, data[0])
@@ -111,7 +111,7 @@ class WriteRpcJsonSpec extends Specification {
         def call = new ProxyCall(ProxyCall.RpcType.SINGLE)
         call.ids[1] = "aaa"
         def data = [
-                new NativeCall.CallResult(1, null, '"0x98dbb1"'.bytes, null, null, null, null, null)
+                new NativeCall.CallResult(1, null, '"0x98dbb1"'.bytes, null, null, List.of(), null, null)
         ]
         when:
         def act = writer.toJson(call, data[0])
@@ -126,9 +126,9 @@ class WriteRpcJsonSpec extends Specification {
         call.ids[2] = 11
         call.ids[3] = 15
         def data = [
-                new NativeCall.CallResult(1, null, '"0x98dbb1"'.bytes, null, null, null, null, null),
-                new NativeCall.CallResult(2, null, null, new NativeCall.CallError(2, "oops", null, null, null), null, null, null, null),
-                new NativeCall.CallResult(3, null, '{"hash": "0x2484f459dc"}'.bytes, null, null, null, null, null),
+                new NativeCall.CallResult(1, null, '"0x98dbb1"'.bytes, null, null, List.of(), null, null),
+                new NativeCall.CallResult(2, null, null, new NativeCall.CallError(2, "oops", null, null, List.of()), null, List.of(), null, null),
+                new NativeCall.CallResult(3, null, '{"hash": "0x2484f459dc"}'.bytes, null, null, List.of(), null, null),
         ]
         when:
         def act = Flux.fromIterable(data)
@@ -154,7 +154,7 @@ class WriteRpcJsonSpec extends Specification {
         def call = new ProxyCall(ProxyCall.RpcType.SINGLE)
         call.ids[1] = 10
         def data = [
-                new NativeCall.CallResult(1, null, '"0x1"'.bytes, null, null, null, null, null),
+                new NativeCall.CallResult(1, null, '"0x1"'.bytes, null, null, List.of(), null, null),
         ]
         when:
         def act = Flux.fromIterable(data)

--- a/src/test/groovy/io/emeraldpay/dshackle/reader/BroadcastReaderSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/reader/BroadcastReaderSpec.groovy
@@ -182,7 +182,7 @@ class BroadcastReaderSpec extends Specification {
         when:
         def act = reader
                 .read(new ChainRequest("eth_sendRawTransaction", new ListParams(["0x1"])))
-                .switchIfEmpty(Mono.just(new RequestReader.Result(new byte[0], null, 0, null, null)))
+                .switchIfEmpty(Mono.just(new RequestReader.Result(new byte[0], null, 0, List.of(), null)))
         then:
         StepVerifier.create(act)
                 .expectErrorMessage("Unhandled Upstream error")

--- a/src/test/groovy/io/emeraldpay/dshackle/rpc/NativeCallSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/rpc/NativeCallSpec.groovy
@@ -123,7 +123,7 @@ class NativeCallSpec extends Specification {
         def nativeCall = nativeCall()
         nativeCall.requestReaderFactory = Mock(RequestReaderFactory) {
             1 * create(_) >> Mock(RequestReader) {
-                1 * read(_) >> Mono.just(new RequestReader.Result("\"foo\"".bytes, null, 1, new Upstream.UpstreamSettingsData((byte)1, "test", "v"), null))
+                1 * read(_) >> Mono.just(new RequestReader.Result("\"foo\"".bytes, null, 1, List.of(new Upstream.UpstreamSettingsData((byte)1, "test", "v")), null))
             }
         }
         def call = new NativeCall.ValidCallContext(1, 10, TestingCommons.multistream(TestingCommons.api()), new Selector.UpstreamFilter(Selector.empty), quorum,
@@ -170,7 +170,7 @@ class NativeCallSpec extends Specification {
         nativeCall.requestReaderFactory = Mock(RequestReaderFactory) {
             1 * create(_) >> Mock(RequestReader) {
                 1 * read(new ChainRequest("eth_test", new ListParams(), 10)) >> Mono.error(
-                        new ChainException(ChainResponse.Id.from(12), new ChainCallError(-32123, "Foo Bar", "Foo Bar Baz"), null, true, null)
+                        new ChainException(ChainResponse.Id.from(12), new ChainCallError(-32123, "Foo Bar", "Foo Bar Baz"), List.of(), true, null)
                 )
             }
         }
@@ -231,7 +231,7 @@ class NativeCallSpec extends Specification {
 
         when:
         def resp = nativeCall.buildResponse(
-                new NativeCall.CallResult(1561, 10, objectMapper.writeValueAsBytes(json), null, null, null, null, null)
+                new NativeCall.CallResult(1561, 10, objectMapper.writeValueAsBytes(json), null, null, List.of(), null, null)
         )
         then:
         resp.id == 1561
@@ -246,7 +246,7 @@ class NativeCallSpec extends Specification {
 
         when:
         def resp = nativeCall.buildResponse(
-                new NativeCall.CallResult(1561, 10, objectMapper.writeValueAsBytes(json), null, new ResponseSigner.Signature("sig1".bytes, "test", 100), new Upstream.UpstreamSettingsData("test"), null, null)
+                new NativeCall.CallResult(1561, 10, objectMapper.writeValueAsBytes(json), null, new ResponseSigner.Signature("sig1".bytes, "test", 100), List.of(new Upstream.UpstreamSettingsData("test")), null, null)
         )
         then:
         resp.id == 1561
@@ -609,7 +609,7 @@ class NativeCallSpec extends Specification {
         def nativeCall = nativeCall(multistreamHolder)
         nativeCall.requestReaderFactory = Mock(RequestReaderFactory) {
             1 * create(_) >> Mock(RequestReader) {
-                1 * read(_) >> Mono.just(new RequestReader.Result("\"0xab\"".bytes, null, 1, new Upstream.UpstreamSettingsData((byte) 255, "", ""), null))
+                1 * read(_) >> Mono.just(new RequestReader.Result("\"0xab\"".bytes, null, 1, List.of(new Upstream.UpstreamSettingsData((byte) 255, "", "")), null))
             }
         }
         def call = new NativeCall.ValidCallContext(1, 10, multistream, new Selector.UpstreamFilter(Selector.empty), quorum,
@@ -642,7 +642,7 @@ class NativeCallSpec extends Specification {
         def nativeCall = nativeCall(multistreamHolder)
         nativeCall.requestReaderFactory = Mock(RequestReaderFactory) {
             1 * create(_) >> Mock(RequestReader) {
-                1 * read(_) >> Mono.just(new RequestReader.Result("\"0xab\"".bytes, null, 1, new Upstream.UpstreamSettingsData((byte) 1, "", ""), null))
+                1 * read(_) >> Mono.just(new RequestReader.Result("\"0xab\"".bytes, null, 1, List.of(new Upstream.UpstreamSettingsData((byte) 1, "", "")), null))
             }
         }
         def call = new NativeCall.ValidCallContext(1, 10, multistream, new Selector.UpstreamFilter(Selector.empty), quorum,

--- a/src/test/groovy/io/emeraldpay/dshackle/test/ApiReaderMock.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/test/ApiReaderMock.groovy
@@ -108,7 +108,7 @@ class ApiReaderMock implements Reader<ChainRequest, ChainResponse> {
                 }
                 error = new ChainCallError(-32601, "Method ${request.method} with ${request.params} is not mocked")
             }
-            return new ChainResponse(result, error, ChainResponse.Id.from(request.id), null, null, null, null)
+            return new ChainResponse(result, error, ChainResponse.Id.from(request.id), null, null, List.of(), null)
         } as Callable<ChainResponse>
         return Mono.fromCallable(call)
     }

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumCachingReaderSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumCachingReaderSpec.groovy
@@ -33,7 +33,7 @@ class EthereumDirectReaderSpec extends Specification {
 
     String hash1 = "0x40d15edaff9acdabd2a1c96fd5f683b3300aad34e7015f34def3c56ba8a7ffb5"
     String address1 = "0xe0aadb0a012dbcdc529c4c743d3e0385a0b54d3d"
-    Upstream.UpstreamSettingsData data = new Upstream.UpstreamSettingsData("test")
+    List<Upstream.UpstreamSettingsData> data = List.of(new Upstream.UpstreamSettingsData("test"))
     def "Reads block by finalization"() {
         setup:
         def json = new BlockJson().tap {

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReaderSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReaderSpec.groovy
@@ -73,7 +73,7 @@ class EthereumLocalReaderSpec extends Specification {
             _ * txByHashAsCont() >> new EmptyReader<>()
             1 * blocksByHeightAsCont() >> Mock(Reader) {
                 1 * read(101L) >> Mono.just(
-                        new EthereumDirectReader.Result<>(TestingCommons.blockForEthereum(101L), null)
+                        new EthereumDirectReader.Result<>(TestingCommons.blockForEthereum(101L), List.of())
                 )
             }
         }
@@ -101,7 +101,7 @@ class EthereumLocalReaderSpec extends Specification {
             _ * txByHashAsCont() >> new EmptyReader<>()
             1 * blocksByHeightAsCont() >> Mock(Reader) {
                 1 * read(0L) >> Mono.just(
-                        new EthereumDirectReader.Result<>(TestingCommons.blockForEthereum(0L), null)
+                        new EthereumDirectReader.Result<>(TestingCommons.blockForEthereum(0L), List.of())
                 )
             }
         }
@@ -129,7 +129,7 @@ class EthereumLocalReaderSpec extends Specification {
             _ * txByHashAsCont() >> new EmptyReader<>()
             1 * blocksByHeightAsCont() >> Mock(Reader) {
                 1 * read(74735L) >> Mono.just(
-                        new EthereumDirectReader.Result<>(TestingCommons.blockForEthereum(74735L), null)
+                        new EthereumDirectReader.Result<>(TestingCommons.blockForEthereum(74735L), List.of())
                 )
             }
         }
@@ -155,7 +155,7 @@ class EthereumLocalReaderSpec extends Specification {
         def reader = Mock(EthereumCachingReader) {
             1 * blockByFinalization() >> Mock(Reader) {
                 1 * read(FinalizationType.SAFE_BLOCK) >> Mono.just(
-                        new EthereumDirectReader.Result<>(TestingCommons.blockForEthereum(74735L), null)
+                        new EthereumDirectReader.Result<>(TestingCommons.blockForEthereum(74735L), List.of())
                 )
             }
         }

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ProduceLogsSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ProduceLogsSpec.groovy
@@ -17,7 +17,6 @@ package io.emeraldpay.dshackle.upstream.ethereum.subscribe
 
 import io.emeraldpay.dshackle.Chain
 import io.emeraldpay.dshackle.data.BlockId
-import io.emeraldpay.dshackle.data.TxId
 import io.emeraldpay.dshackle.reader.Reader
 import io.emeraldpay.dshackle.upstream.ethereum.EthereumDirectReader
 import io.emeraldpay.dshackle.upstream.ethereum.domain.Address
@@ -47,7 +46,7 @@ class ProduceLogsSpec extends Specification {
         setup:
         def logs = Mock(Reader) {
             1 * it.read(BlockId.from("0x668b92d6b8c7db1350fd527fec4885ce5be2159b2b7daf6b126babdcbaa349da")) >>
-                    Mono.just(new EthereumDirectReader.Result<>([], null))
+                    Mono.just(new EthereumDirectReader.Result<>([], List.of()))
         }
         def producer = new ProduceLogs(logs, Chain.ETHEREUM__MAINNET)
         def update = new ConnectBlockUpdates.Update(
@@ -69,7 +68,7 @@ class ProduceLogsSpec extends Specification {
 
         def logs = Mock(Reader) {
             1 * it.read(BlockId.from("0x668b92d6b8c7db1350fd527fec4885ce5be2159b2b7daf6b126babdcbaa349da")) >>
-                    Mono.just(new EthereumDirectReader.Result<>(logs, null))
+                    Mono.just(new EthereumDirectReader.Result<>(logs, List.of()))
         }
         def producer = new ProduceLogs(logs, Chain.ETHEREUM__MAINNET)
         def update = new ConnectBlockUpdates.Update(
@@ -92,7 +91,7 @@ class ProduceLogsSpec extends Specification {
         setup:
         def logs = Mock(Reader) {
             1 * it.read(BlockId.from("0x668b92d6b8c7db1350fd527fec4885ce5be2159b2b7daf6b126babdcbaa349da")) >>
-                    Mono.just(new EthereumDirectReader.Result<>(logs, null))
+                    Mono.just(new EthereumDirectReader.Result<>(logs, List.of()))
         }
         def producer = new ProduceLogs(logs, Chain.ETHEREUM__MAINNET)
         def update1 = new ConnectBlockUpdates.Update(

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/rpcclient/JsonRpcResponseSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/rpcclient/JsonRpcResponseSpec.groovy
@@ -65,7 +65,7 @@ class JsonRpcResponseSpec extends Specification {
 
     def "Serialize int id and null result"() {
         setup:
-        def json = new ChainResponse("null".bytes, null, new ChainResponse.NumberId(1), null, null, null)
+        def json = new ChainResponse("null".bytes, null, new ChainResponse.NumberId(1), null, null, List.of())
         when:
         def act = objectMapper.writeValueAsString(json)
         then:
@@ -74,7 +74,7 @@ class JsonRpcResponseSpec extends Specification {
 
     def "Serialize int id and string result"() {
         setup:
-        def json = new ChainResponse('"Hello World"'.bytes, null, new ChainResponse.NumberId(10), null, null, null)
+        def json = new ChainResponse('"Hello World"'.bytes, null, new ChainResponse.NumberId(10), null, null, List.of())
         when:
         def act = objectMapper.writeValueAsString(json)
         then:
@@ -83,7 +83,7 @@ class JsonRpcResponseSpec extends Specification {
 
     def "Serialize int id and object result"() {
         setup:
-        def json = new ChainResponse('{"foo": "Hello World", "bar": 1}'.bytes, null, new ChainResponse.NumberId(101), null, null, null)
+        def json = new ChainResponse('{"foo": "Hello World", "bar": 1}'.bytes, null, new ChainResponse.NumberId(101), null, null, List.of())
         when:
         def act = objectMapper.writeValueAsString(json)
         then:
@@ -92,7 +92,7 @@ class JsonRpcResponseSpec extends Specification {
 
     def "Serialize int id and error"() {
         setup:
-        def json = new ChainResponse(null, new ChainCallError(-32041, "Oooops"), new ChainResponse.NumberId(101), null, null, null)
+        def json = new ChainResponse(null, new ChainCallError(-32041, "Oooops"), new ChainResponse.NumberId(101), null, null, List.of())
         when:
         def act = objectMapper.writeValueAsString(json)
         then:
@@ -101,7 +101,7 @@ class JsonRpcResponseSpec extends Specification {
 
     def "Serialize string id and null result"() {
         setup:
-        def json = new ChainResponse("null".bytes, null, new ChainResponse.StringId("asf01t1gg"), null, null, null)
+        def json = new ChainResponse("null".bytes, null, new ChainResponse.StringId("asf01t1gg"), null, null, List.of())
         when:
         def act = objectMapper.writeValueAsString(json)
         then:
@@ -110,7 +110,7 @@ class JsonRpcResponseSpec extends Specification {
 
     def "Serialize string id and string result"() {
         setup:
-        def json = new ChainResponse('"Hello World"'.bytes, null, new ChainResponse.StringId("10"), null, null, null)
+        def json = new ChainResponse('"Hello World"'.bytes, null, new ChainResponse.StringId("10"), null, null, List.of())
         when:
         def act = objectMapper.writeValueAsString(json)
         then:
@@ -119,7 +119,7 @@ class JsonRpcResponseSpec extends Specification {
 
     def "Serialize string id and object result"() {
         setup:
-        def json = new ChainResponse('{"foo": "Hello World", "bar": 1}'.bytes, null, new ChainResponse.StringId("g8gk19g"), null, null, null)
+        def json = new ChainResponse('{"foo": "Hello World", "bar": 1}'.bytes, null, new ChainResponse.StringId("g8gk19g"), null, null, List.of())
         when:
         def act = objectMapper.writeValueAsString(json)
         then:
@@ -130,7 +130,7 @@ class JsonRpcResponseSpec extends Specification {
         setup:
         def json = new ChainResponse(null,
                 new ChainCallError(-32041, "Oooops"),
-                new ChainResponse.StringId("9kbo29gkaasf"), null, null, null  )
+                new ChainResponse.StringId("9kbo29gkaasf"), null, null, List.of())
         when:
         def act = objectMapper.writeValueAsString(json)
         then:

--- a/src/test/kotlin/io/emeraldpay/dshackle/rpc/NativeCallTest.kt
+++ b/src/test/kotlin/io/emeraldpay/dshackle/rpc/NativeCallTest.kt
@@ -33,7 +33,7 @@ class NativeCallTest {
             ),
         ) {
             on { nativeCallResult(request) } doReturn Flux.just(
-                NativeCall.CallResult.ok(1, null, "0x1".toByteArray(), null, Upstream.UpstreamSettingsData("id"), null),
+                NativeCall.CallResult.ok(1, null, "0x1".toByteArray(), null, listOf(Upstream.UpstreamSettingsData("id")), null),
             )
         }
 
@@ -63,7 +63,7 @@ class NativeCallTest {
             ),
         ) {
             on { nativeCallResult(request) } doReturn Flux.just(
-                NativeCall.CallResult(1, null, null, NativeCall.CallError(50001, "message", null, null, Upstream.UpstreamSettingsData("upId")), null, null),
+                NativeCall.CallResult(1, null, null, NativeCall.CallError(50001, "message", null, null, listOf(Upstream.UpstreamSettingsData("upId"))), null, null),
             )
         }
 
@@ -99,7 +99,7 @@ class NativeCallTest {
             ),
         ) {
             on { nativeCallResult(request) } doReturn Flux.just(
-                NativeCall.CallResult.ok(1, null, "".toByteArray(), null, Upstream.UpstreamSettingsData("upId"), null, chunks),
+                NativeCall.CallResult.ok(1, null, "".toByteArray(), null, listOf(Upstream.UpstreamSettingsData("upId")), null, chunks),
             )
         }
 


### PR DESCRIPTION
To understand clearly what upstreams handled transactions now we pass all of them in the grpc responses