### PR TITLE
feature: support aarch64 on ubuntu 24.04

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,7 @@ dependencies {
 
     implementation(variantOf(libs.netty.tcnative.boringssl) { classifier("osx-aarch_64") })
     implementation(variantOf(libs.netty.tcnative.boringssl) { classifier("linux-x86_64") })
+    implementation(variantOf(libs.netty.tcnative.boringssl) { classifier("linux-aarch64") })
     implementation(variantOf(libs.netty.tcnative.boringssl) { classifier("osx-x86_64") })
     implementation 'dshackle:foundation:1.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,8 @@ group = 'io.emeraldpay.dshackle'
 version = getVersion()
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_20
-    targetCompatibility = JavaVersion.VERSION_20
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 repositories {
@@ -132,10 +132,10 @@ tasks.withType(Test) { jvmArgs += "--enable-preview" }
 tasks.withType(JavaExec) { jvmArgs += "--enable-preview" }
 
 compileKotlin {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_20)
+    compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
 }
 compileTestKotlin {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_20)
+    compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
 }
 
 test {

--- a/foundation/build.gradle
+++ b/foundation/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.9.10'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.25'
     id 'maven-publish'
 }
 

--- a/foundation/gradle/wrapper/gradle-wrapper.properties
+++ b/foundation/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,9 +8,9 @@ reactive-grpc = "1.2.0"
 spring-boot = "2.6.15"
 spring-security = "5.5.3"
 reactor = "3.4.32"
-netty = "4.1.97.Final"
-netty-tcnative = "2.0.61.Final"
-kotlin = "1.9.10"
+netty = "4.1.113.Final"
+netty-tcnative = "2.0.66.Final"
+kotlin = "1.9.25"
 httpcomponents = "4.5.8"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
To support aarch64 on ubuntu 24.04, OpenSSL v3 support is needed. This implies using the latest netty tcnative release and the related version bump-ups.