### PR TITLE
fix log: Failed to save TX to Redis: ERR invalid expire time in 'sete…

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/cache/OnTxRedisCache.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/cache/OnTxRedisCache.kt
@@ -148,7 +148,7 @@ abstract class OnTxRedisCache<T>(
         // keep for hour, but block create 10 seconds ago cache for 10 seconds, as it
         // still can be replaced in the blockchain
         val age = Instant.now().epochSecond - blockTime.epochSecond
-        return min(age, TimeUnit.HOURS.toSeconds(MAX_CACHE_TIME_HOURS))
+        return min(max(age, 1L), TimeUnit.HOURS.toSeconds(MAX_CACHE_TIME_HOURS))
     }
 
     /**


### PR DESCRIPTION
…x' command

2025-07-20 08:22:36.757  WARN [dshackle,e77d18e034b0efc9005956fceb7dd546,db8906c02fc1325d] 1 --- [llEventLoop-4-2] i.e.dshackle.cache.OnTxRedisCache        : Failed to save TX to Redis: ERR invalid expire time in 'setex' command
