### PR TITLE
Cap timer histogram buckets at 13 instead of 69

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/monitoring/MonitoringSetup.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/monitoring/MonitoringSetup.kt
@@ -30,9 +30,9 @@ import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import io.prometheus.metrics.exporter.httpserver.HTTPServer
 import jakarta.annotation.PostConstruct
-import java.time.Duration
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.time.Duration
 
 @Service
 class MonitoringSetup(

--- a/src/main/kotlin/io/emeraldpay/dshackle/monitoring/MonitoringSetup.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/monitoring/MonitoringSetup.kt
@@ -33,6 +33,7 @@ import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.Duration
+import java.time.temporal.ChronoUnit
 
 @Service
 class MonitoringSetup(
@@ -56,7 +57,7 @@ class MonitoringSetup(
          */
         private val LATENCY_BUCKETS = listOf(
             Duration.ofMillis(1),
-            Duration.ofMicros(2500),
+            Duration.of(2500, ChronoUnit.MICROS),
             Duration.ofMillis(5),
             Duration.ofMillis(10),
             Duration.ofMillis(25),

--- a/src/main/kotlin/io/emeraldpay/dshackle/monitoring/MonitoringSetup.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/monitoring/MonitoringSetup.kt
@@ -25,10 +25,12 @@ import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics
 import io.micrometer.core.instrument.config.MeterFilter
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig
 import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import io.prometheus.metrics.exporter.httpserver.HTTPServer
 import jakarta.annotation.PostConstruct
+import java.time.Duration
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -39,6 +41,65 @@ class MonitoringSetup(
 
     companion object {
         private val log = LoggerFactory.getLogger(MonitoringSetup::class.java)
+
+        /**
+         * Explicit latency buckets for every timer that asks for a histogram.
+         *
+         * `Timer.publishPercentileHistogram()` makes Micrometer emit its own exponential ladder, which
+         * expands to 69 `le` buckets per label set (0.001s..30s). On a busy upstream that is 10 KB of
+         * `/metrics` body per (chain, method, upstream) combination, and the two biggest timer families
+         * alone accounted for 91% of a 74 MB response - past the 64 MB scrape limit of our Prometheus
+         * agent, which drops the whole response and loses every dshackle metric with it.
+         *
+         * These 12 boundaries keep p50/p90/p95/p99 usable across the range we actually serve (sub-ms
+         * cache hits up to the 30s timeout) at 13 buckets including `+Inf` - a 5.3x cut.
+         */
+        private val LATENCY_BUCKETS = listOf(
+            Duration.ofMillis(1),
+            Duration.ofMicros(2500),
+            Duration.ofMillis(5),
+            Duration.ofMillis(10),
+            Duration.ofMillis(25),
+            Duration.ofMillis(50),
+            Duration.ofMillis(100),
+            Duration.ofMillis(250),
+            Duration.ofMillis(500),
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(5),
+            Duration.ofSeconds(30),
+        )
+
+        /**
+         * Micrometer stores timer values in nanoseconds, so service level objectives set through
+         * [DistributionStatisticConfig] must be nanoseconds too. This is the same conversion
+         * `Timer.Builder.serviceLevelObjectives(Duration...)` does internally.
+         */
+        private val LATENCY_BUCKETS_NANOS =
+            LATENCY_BUCKETS.map { it.toNanos().toDouble() }.toDoubleArray()
+
+        /**
+         * Replaces Micrometer's 69-bucket percentile histogram with [LATENCY_BUCKETS].
+         *
+         * Only touches timers that already asked for a percentile histogram, so a timer without one
+         * never gains buckets, and non-timer distributions (whose recorded values are not nanoseconds)
+         * are left alone. Values set on the builder win over the incoming config; the rest is inherited.
+         */
+        @JvmStatic
+        fun latencyHistogramFilter(): MeterFilter = object : MeterFilter {
+            override fun configure(
+                id: Meter.Id,
+                config: DistributionStatisticConfig,
+            ): DistributionStatisticConfig {
+                if (id.type != Meter.Type.TIMER || config.isPercentileHistogram != true) {
+                    return config
+                }
+                return DistributionStatisticConfig.builder()
+                    .percentilesHistogram(false)
+                    .serviceLevelObjectives(*LATENCY_BUCKETS_NANOS)
+                    .build()
+                    .merge(config)
+            }
+        }
     }
 
     @PostConstruct
@@ -56,6 +117,7 @@ class MonitoringSetup(
                 }
             },
         )
+        Metrics.globalRegistry.config().meterFilter(latencyHistogramFilter())
 
         if (monitoringConfig.enableJvm) {
             ClassLoaderMetrics().bindTo(Metrics.globalRegistry)

--- a/src/test/groovy/io/emeraldpay/dshackle/monitoring/MonitoringSetupSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/monitoring/MonitoringSetupSpec.groovy
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2026 EmeraldPay, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.emeraldpay.dshackle.monitoring
+
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.Timer
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import spock.lang.Specification
+
+import java.time.Duration
+import java.util.regex.Pattern
+
+class MonitoringSetupSpec extends Specification {
+
+    static final Pattern LE = Pattern.compile(/\ble="([^"]+)"/)
+
+    private static PrometheusMeterRegistry registry() {
+        def registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        registry.config().meterFilter(MonitoringSetup.latencyHistogramFilter())
+        return registry
+    }
+
+    /**
+     * Bucket upper bounds of a metric, as doubles. Prometheus writes the last bucket as "+Inf",
+     * which Double.parseDouble does not accept, so it is mapped explicitly.
+     */
+    private static List<Double> bounds(PrometheusMeterRegistry registry, String metric) {
+        def out = []
+        registry.scrape().eachLine { line ->
+            if (line.startsWith(metric + "_bucket")) {
+                def m = LE.matcher(line)
+                if (m.find()) {
+                    def raw = m.group(1)
+                    out.add(raw.endsWith("Inf") ? Double.POSITIVE_INFINITY : Double.parseDouble(raw))
+                }
+            }
+        }
+        return out
+    }
+
+    def "caps a percentile histogram at 13 buckets instead of Micrometer's 69"() {
+        setup:
+        def registry = registry()
+
+        when:
+        Timer.builder("upstream.rpc.conn")
+                .publishPercentileHistogram()
+                .register(registry)
+                .record(Duration.ofMillis(3))
+
+        then:
+        // 12 explicit boundaries plus +Inf. The default percentile ladder would be 69.
+        bounds(registry, "upstream_rpc_conn_seconds").size() == 13
+    }
+
+    def "keeps the boundaries in seconds, not nanoseconds"() {
+        setup:
+        def registry = registry()
+
+        when:
+        Timer.builder("upstream.rpc.conn")
+                .publishPercentileHistogram()
+                .register(registry)
+                .record(Duration.ofMillis(3))
+        def all = bounds(registry, "upstream_rpc_conn_seconds")
+        def finite = all.findAll { !it.isInfinite() }.sort()
+
+        then:
+        // Micrometer wants nanoseconds in DistributionStatisticConfig but exposes seconds. Getting
+        // that conversion wrong gives sub-nanosecond boundaries, which this pins down.
+        all.any { it.isInfinite() }
+        Math.abs(finite.first() - 0.001d) < 1e-9d
+        Math.abs(finite.last() - 30.0d) < 1e-6d
+    }
+
+    def "leaves a timer without a percentile histogram alone"() {
+        setup:
+        def registry = registry()
+
+        when:
+        Timer.builder("request.jsonrpc.call")
+                .register(registry)
+                .record(Duration.ofMillis(3))
+
+        then:
+        bounds(registry, "request_jsonrpc_call_seconds").isEmpty()
+    }
+
+    def "leaves a non-timer distribution alone"() {
+        setup:
+        def registry = registry()
+
+        when:
+        DistributionSummary.builder("upstreams.tried")
+                .publishPercentileHistogram()
+                .register(registry)
+                .record(3.0d)
+        def finite = bounds(registry, "upstreams_tried").findAll { !it.isInfinite() }
+
+        then:
+        // A summary counts upstreams, not nanoseconds, so the latency ladder must not be applied.
+        // 2.5ms is the boundary unique to that ladder.
+        !finite.any { Math.abs(it - 0.0025d) < 1e-9d }
+    }
+}


### PR DESCRIPTION
## Problem

`publishPercentileHistogram()` makes Micrometer expand each timer into a **69-step** exponential `le` ladder (0.001s → 30s). Measured on a live `public-multiregion` pod (image `6a2fb45`, container age 10d22h), that ladder is almost the entire `/metrics` response:

| Metric family | Bytes | Series | % of body |
| --- | --- | --- | --- |
| `dshackle_upstream_rpc_conn_seconds_bucket` | 43.41 MB | 300,840 | 58.3% |
| `dshackle_request_grpc_native_response_seconds_bucket` | 24.46 MB | 195,891 | 32.8% |
| `dshackle_request_grpc_response_seconds_bucket` | 2.28 MB | 21,252 | 3.1% |

Body is **74,507,051 bytes**. Every `*_seconds_bucket` line together is **94.7%** of it. Label cardinality is *not* the issue — `upstream.rpc.conn` has only 4,360 label sets. 4,360 × 69 = 300,840 series exactly. The multiplier is the ladder: **10.10 KB of response body per label set**.

Our metrics agent has a hard 64 MB cap on the raw response body, applied before parsing, with no partial ingestion. Over the cap it drops the **entire** scrape. So two oversized families take out every `dshackle_*` metric from the pod — `upstreams_availability`, `current_head`, `stuck_head`, `upstream_blocks`, the JVM metrics, all of it. Two of our three `public-multiregion` clusters have been dark for 5-6 days each. dshackle itself is healthy throughout; it served 9.27M requests in the 30 minutes before this was measured.

Restarting is not a fix. A fresh pod starts at 42-51 MB — already 66-80% of the cap — and crosses 64 MB in 2-3 days, because the two `ConcurrentHashMap` timer caches (`RequestMetrics.kt:27-33`, `BlockchainRpc.kt:216-219`) never evict and the `method` tag keeps growing. 24.7% of label sets have recorded exactly **one** observation in ten days, and each still costs 10.10 KB on every scrape.

For context on why this got acute recently: #863 added the `method` tag to `upstream.rpc.conn`. That is a genuinely useful label, but it took that family from ~199 label sets (upstream × chain) to 4,360, multiplying a 69-bucket histogram by ~22×, which is roughly +43 MB of body. This PR keeps the label and cuts the buckets instead.

## What this changes

A `MeterFilter` in `MonitoringSetup` replaces the percentile histogram with 12 explicit boundaries — 1ms, 2.5ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 5s, 30s — so **13 buckets including `+Inf`**. One filter covers all six `publishPercentileHistogram()` call sites (`BasicHttpFactory.kt:43`, `BlockchainRpc.kt:204/213/230`, `WsConnectionFactory.kt:40`, `GrpcUpstreams.kt:292`), and a new call site cannot forget it.

Effect on the same pod: **74.5 MB → ~16 MB**, a 5.3× cut on 94.7% of the body.

The filter is deliberately narrow. It returns the incoming config untouched unless the meter is a `TIMER` **and** already asked for a percentile histogram, so:

- no timer ever *gains* buckets (`executor.seconds`, `request.jsonrpc.call` and friends stay bucket-free);
- non-timer distributions are skipped, because their recorded values are not nanoseconds and a latency ladder would be meaningless on them.

Values are set in nanoseconds, which is what `DistributionStatisticConfig` expects for timers — the same conversion `Timer.Builder.serviceLevelObjectives(Duration...)` does internally via `Duration::toNanos`. `merge(config)` is ordered so the builder's values win and everything else is inherited.

## Why 13 buckets and not 20

Sizing against today's 74.5 MB gives the wrong answer. The ceiling matters: dshackle has **no per-user label** anywhere (all 22 label names checked), and `upstream` is strictly 1:1 with `chain`, so the worst case is `Σ over upstreams of allowlist(chain)` — 203 upstreams × 52 upstream-callable methods for a plain EVM chain, plus 788 chain-specific extras. That is 11,344 label sets on `upstream.rpc.conn` and 13,199 on `request.grpc.native.response`, i.e. a **~240 MB ceiling** at 69 buckets.

| Ladder | Body at that ceiling | Under 64 MB? |
| --- | --- | --- |
| 69 (today) | 240.0 MB | no |
| 20 | 77.5 MB | **no** |
| 15 | 60.9 MB | yes |
| **13 (this PR)** | **54.3 MB** | **yes** |
| 12 | 51.0 MB | yes |

A 20-bucket ladder would fix today and break again later. 13 leaves real headroom.

## What this does not change

- No metric is added or removed, and no label changes. `_sum`, `_count`, `_max` are untouched.
- `histogram_quantile` consumers keep working at coarser resolution. Eight panels across two dashboards depend on these buckets, which is why dropping the bucket families outright was rejected.
- `monitoring.extended` is unrelated. It gates four small extras (`no_matching_upstream`, `native_call_failure`, the `FilteredApis` summaries, `ProxyServer.ExtendedRequestMetrics`) and never touched `publishPercentileHistogram()`.

## Still worth doing separately

This PR caps the per-label-set cost. It does not stop label sets accumulating, so the body still grows — about 4.6× slower. Two follow-ups, deliberately out of scope here:

1. Bound the two timer caches — evict a method's timer after an idle period, or skip creating one below a call-count threshold. That would remove the 24.7% of label sets carrying a single observation.
2. `BlockchainRpc.kt:78-81` builds a timer from the caller-supplied `item.method` on the request path with no validation, and that cache never evicts. Observed values are all real method names today, so there is no evidence of a problem in practice, but nothing in dshackle bounds it.

## Testing

`MonitoringSetupSpec` covers the filter against a local `PrometheusMeterRegistry`, so it asserts on real scrape output rather than on config objects:

- a timer with a percentile histogram exposes exactly 13 buckets, not 69;
- the boundaries come out in **seconds** (min 0.001, max 30.0) — this is the regression test for the nanosecond conversion, which silently produces sub-nanosecond buckets if you get it backwards;
- a timer without a percentile histogram exposes no buckets;
- a `DistributionSummary` with a percentile histogram does not get the latency ladder.

**I could not compile or run this locally — there is no JDK 21 on the machine I worked from, so I am relying on CI (`make test`, which runs `./gradlew check` including ktlint) for compile and test verification.** Every Micrometer API used here was checked against the published `micrometer-core:1.16.5` sources rather than from memory: `MeterFilter.configure` receives the post-`map` id, `serviceLevelObjectives` takes `double...` in nanoseconds for timers, `merge` lets the receiver win, and with `percentilesHistogram(false)` only the SLO boundaries become buckets with no min/max clamping.

## Verification after deploy

```promql
# should read 13, not 69
count by (job) (count by (job, le) (dshackle_upstream_rpc_conn_seconds_bucket))

# should drop well under 54,400,000
max by (drpc_cluster, job) (scrape_response_size_bytes{job=~"dshackle.*"})
```

---